### PR TITLE
Implement Arn* operators and tests

### DIFF
--- a/pkg/policy/condition/operations.go
+++ b/pkg/policy/condition/operations.go
@@ -41,4 +41,10 @@ const (
 	// IP Address Functions
 	IpAddress    = "IpAddress"
 	NotIpAddress = "NotIpAddress"
+
+	// Arn functions
+	ArnEquals    = "ArnEquals"
+	ArnNotEquals = "ArnNotEquals"
+	ArnLike      = "ArnLike"
+	ArnNotLike   = "ArnNotLike"
 )

--- a/pkg/sim/eval_condition.go
+++ b/pkg/sim/eval_condition.go
@@ -215,6 +215,35 @@ var ConditionOperatorMap = map[string]CondInner{
 			),
 		),
 	),
+
+	// ------------------------------------------------------------------------------
+	// ARN Functions
+	// ------------------------------------------------------------------------------
+
+	condition.ArnEquals: Mod_ResolveVariables(
+		Cond_MatchAny(
+			Cond_ArnLike,
+		),
+	),
+	condition.ArnNotEquals: Mod_ResolveVariables(
+		Mod_Not(
+			Cond_MatchAny(
+				Cond_ArnLike,
+			),
+		),
+	),
+	condition.ArnLike: Mod_ResolveVariables(
+		Cond_MatchAny(
+			Cond_ArnLike,
+		),
+	),
+	condition.ArnNotLike: Mod_ResolveVariables(
+		Mod_Not(
+			Cond_MatchAny(
+				Cond_ArnLike,
+			),
+		),
+	),
 }
 
 // --------------------------------------------------------------------------------
@@ -276,6 +305,11 @@ func Cond_NumericGreaterThanEquals(trc *Trace, left, right int) bool {
 // Cond_IpAddress defines the `IpAddress` condition function
 func Cond_IpAddress(trc *Trace, left netip.Addr, right netip.Prefix) bool {
 	return right.Contains(left)
+}
+
+// Cond_ArnLike defines the `ArnLike` condition function
+func Cond_ArnLike(trc *Trace, left, right string) bool {
+	return wildcard.MatchArn(right, left)
 }
 
 // --------------------------------------------------------------------------------


### PR DESCRIPTION
### Overview

This PR implements all Arn operators currently supported by AWS. This includes:
* `ArnEquals`
* `ArnNotEquals`
* `ArnLike`
* `ArnNotLike`