### PR TITLE
Feature Bundle

### DIFF
--- a/cmd/yams/cli/flags.go
+++ b/cmd/yams/cli/flags.go
@@ -49,6 +49,7 @@ type Flags struct {
 	Sources MultiString
 	Refresh int
 	Debug   bool
+	Env     MultiString
 
 	// inventory
 	Key    string
@@ -127,6 +128,9 @@ func Parse() (*Flags, error) {
 		fs.IntVar(&opts.Refresh, "r", 0, "alias for -refresh")
 		fs.IntVar(&opts.Refresh, "refresh", 0,
 			"refresh rate (in seconds) for specified sources; defaults to no refresh")
+
+		fs.Var(&opts.Env, "e", "alias for -env")
+		fs.Var(&opts.Env, "env", "environment variables to report in /status endpoint")
 
 		err = fs.Parse(os.Args[2:])
 		args = fs.Args()

--- a/cmd/yams/server/server.go
+++ b/cmd/yams/server/server.go
@@ -11,7 +11,7 @@ import (
 
 // Logic for the "server" subcommand
 func Run(opts *cli.Flags) {
-	srv, err := server.NewServer(opts.Addr)
+	srv, err := server.NewServer(opts)
 	if err != nil {
 		cli.Fail("error starting server: %v", err)
 	}

--- a/pkg/entities/freeze.go
+++ b/pkg/entities/freeze.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"fmt"
 
+	arnlib "github.com/nsiow/yams/pkg/arn"
 	"github.com/nsiow/yams/pkg/policy"
 )
 
@@ -10,17 +11,17 @@ import (
 // Universe
 //
 // TODO(nsiow) does it make any sense for principals/resources to have universe pointers if we are
-//             going to allow freezing from other universes
-// TODO(nsiow) update these to not be a method and instead take a list of universes
+//             going to allow freezing from other uvs
+// TODO(nsiow) update these to not be a method and instead take a list of uvs
 // -------------------------------------------------------------------------------------------------
 
-func (u *Universe) FrozenPrincipals(overlay *Universe) ([]FrozenPrincipal, error) {
+func (u *Universe) FrozenPrincipals(strict bool, overlay *Universe) ([]FrozenPrincipal, error) {
 	var fs []FrozenPrincipal
 
 	uvs := u.Overlay(overlay)
 	for _, uv := range uvs {
 		for p := range uv.Principals() {
-			f, err := p.FreezeWith(uvs...)
+			f, err := p.FreezeWith(strict, uvs...)
 			if err != nil {
 				return nil, err
 			}
@@ -31,13 +32,13 @@ func (u *Universe) FrozenPrincipals(overlay *Universe) ([]FrozenPrincipal, error
 	return fs, nil
 }
 
-func (u *Universe) FrozenResources(overlay *Universe) ([]FrozenResource, error) {
+func (u *Universe) FrozenResources(strict bool, overlay *Universe) ([]FrozenResource, error) {
 	var fs []FrozenResource
 
 	uvs := u.Overlay(overlay)
 	for _, uv := range uvs {
 		for r := range uv.Resources() {
-			f, err := r.FreezeWith(uvs...)
+			f, err := r.FreezeWith(strict, uvs...)
 			if err != nil {
 				return nil, err
 			}
@@ -64,10 +65,10 @@ func (a *Account) Freeze() (FrozenAccount, error) {
 		return FrozenAccount{}, fmt.Errorf("cannot freeze; account is missing universe: %s", a.Id)
 	}
 
-	return a.FreezeWith(a.uv)
+	return a.FreezeWith(false, a.uv)
 }
 
-func (a *Account) FreezeWith(universes ...*Universe) (FrozenAccount, error) {
+func (a *Account) FreezeWith(strict bool, uvs ...*Universe) (FrozenAccount, error) {
 	frozen := FrozenAccount{
 		Id:       a.Id,
 		OrgId:    a.OrgId,
@@ -75,7 +76,7 @@ func (a *Account) FreezeWith(universes ...*Universe) (FrozenAccount, error) {
 	}
 
 	for _, node := range a.OrgNodes {
-		frozenNode, err := freezeOrgNode(&node, universes...)
+		frozenNode, err := node.FreezeWith(strict, uvs...)
 		if err != nil {
 			return FrozenAccount{}, err
 		}
@@ -100,24 +101,24 @@ type FrozenOrgNode struct {
 	RCPs []ManagedPolicy
 }
 
-func freezeOrgNode(node *OrgNode, universes ...*Universe) (FrozenOrgNode, error) {
+func (n *OrgNode) FreezeWith(strict bool, uvs ...*Universe) (FrozenOrgNode, error) {
 	frozen := FrozenOrgNode{
-		Id:   node.Id,
-		Type: node.Type,
-		Arn:  node.Arn,
-		Name: node.Name,
+		Id:   n.Id,
+		Type: n.Type,
+		Arn:  n.Arn,
+		Name: n.Name,
 	}
 
-	for _, arn := range node.SCPs {
-		policies, err := freezePolicy(arn, universes...)
+	for _, arn := range n.SCPs {
+		policies, err := freezePolicy(arn, strict, uvs...)
 		if err != nil {
 			return FrozenOrgNode{}, err
 		}
 		frozen.SCPs = append(frozen.SCPs, policies)
 	}
 
-	for _, arn := range node.RCPs {
-		policies, err := freezePolicy(arn, universes...)
+	for _, arn := range n.RCPs {
+		policies, err := freezePolicy(arn, strict, uvs...)
 		if err != nil {
 			return FrozenOrgNode{}, err
 		}
@@ -145,10 +146,10 @@ func (g *Group) Freeze() (FrozenGroup, error) {
 		return FrozenGroup{}, fmt.Errorf("cannot freeze; group is missing universe: %s", g.Arn)
 	}
 
-	return g.FreezeWith(g.uv)
+	return g.FreezeWith(false, g.uv)
 }
 
-func (g *Group) FreezeWith(universes ...*Universe) (FrozenGroup, error) {
+func (g *Group) FreezeWith(strict bool, uvs ...*Universe) (FrozenGroup, error) {
 	f := FrozenGroup{
 		Type:           g.Type,
 		AccountId:      g.AccountId,
@@ -158,7 +159,7 @@ func (g *Group) FreezeWith(universes ...*Universe) (FrozenGroup, error) {
 
 	var err error
 
-	f.AttachedPolicies, err = freezePolicies(g.AttachedPolicies, universes...)
+	f.AttachedPolicies, err = freezePolicies(g.AttachedPolicies, strict, uvs...)
 	if err != nil {
 		return FrozenGroup{}, err
 	}
@@ -188,10 +189,10 @@ func (p *Principal) Freeze() (FrozenPrincipal, error) {
 		return FrozenPrincipal{}, fmt.Errorf("cannot freeze; principal is missing universe: %s", p.Arn)
 	}
 
-	return p.FreezeWith(p.uv)
+	return p.FreezeWith(false, p.uv)
 }
 
-func (p *Principal) FreezeWith(universes ...*Universe) (FrozenPrincipal, error) {
+func (p *Principal) FreezeWith(strict bool, uvs ...*Universe) (FrozenPrincipal, error) {
 	f := FrozenPrincipal{
 		Type:           p.Type,
 		AccountId:      p.AccountId,
@@ -202,9 +203,9 @@ func (p *Principal) FreezeWith(universes ...*Universe) (FrozenPrincipal, error) 
 
 	var err error
 
-	for _, uv := range universes {
+	for _, uv := range uvs {
 		if account, ok := uv.Account(f.AccountId); ok {
-			f.Account, err = account.FreezeWith(uv)
+			f.Account, err = account.FreezeWith(strict, uvs...)
 			if err != nil {
 				return FrozenPrincipal{}, err
 			}
@@ -212,21 +213,21 @@ func (p *Principal) FreezeWith(universes ...*Universe) (FrozenPrincipal, error) 
 	}
 
 	if len(p.AttachedPolicies) > 0 {
-		f.AttachedPolicies, err = freezePolicies(p.AttachedPolicies, universes...)
+		f.AttachedPolicies, err = freezePolicies(p.AttachedPolicies, strict, uvs...)
 		if err != nil {
 			return FrozenPrincipal{}, err
 		}
 	}
 
 	if len(p.Groups) > 0 {
-		f.Groups, err = freezeGroupsByArn(p.Groups, universes...)
+		f.Groups, err = freezeGroupsByArn(p.Groups, strict, uvs...)
 		if err != nil {
 			return FrozenPrincipal{}, err
 		}
 	}
 
 	if len(p.PermissionsBoundary) > 0 {
-		f.PermissionBoundary, err = freezePolicy(p.PermissionsBoundary, universes...)
+		f.PermissionBoundary, err = freezePolicy(p.PermissionsBoundary, strict, uvs...)
 		if err != nil {
 			return FrozenPrincipal{}, err
 		}
@@ -256,10 +257,10 @@ func (r *Resource) Freeze() (FrozenResource, error) {
 			fmt.Errorf("cannot freeze; resource is missing universe: %s", r.Arn)
 	}
 
-	return r.FreezeWith(r.uv)
+	return r.FreezeWith(false, r.uv)
 }
 
-func (r *Resource) FreezeWith(universes ...*Universe) (FrozenResource, error) {
+func (r *Resource) FreezeWith(strict bool, uvs ...*Universe) (FrozenResource, error) {
 	f := FrozenResource{
 		Type:      r.Type,
 		AccountId: r.AccountId,
@@ -270,9 +271,9 @@ func (r *Resource) FreezeWith(universes ...*Universe) (FrozenResource, error) {
 
 	var err error
 
-	for _, uv := range universes {
+	for _, uv := range uvs {
 		if account, ok := uv.Account(f.AccountId); ok {
-			f.Account, err = account.FreezeWith(universes...)
+			f.Account, err = account.FreezeWith(strict, uvs...)
 			if err != nil {
 				return FrozenResource{}, err
 			}
@@ -286,22 +287,43 @@ func (r *Resource) FreezeWith(universes ...*Universe) (FrozenResource, error) {
 // Helper functions
 // -------------------------------------------------------------------------------------------------
 
-func freezePolicy(arn Arn, universes ...*Universe) (ManagedPolicy, error) {
-	for _, uv := range universes {
+func makeEmptyPolicy(arn Arn) ManagedPolicy {
+	return ManagedPolicy{
+		Type:      "AWS::IAM::Policy",
+		AccountId: arnlib.Account(arn),
+		Arn:       arn,
+		Name:      arnlib.ResourceId(arn),
+	}
+}
+
+func makeEmptyGroup(arn Arn) FrozenGroup {
+	return FrozenGroup{
+		Type:      "AWS::IAM::Group",
+		AccountId: arnlib.Account(arn),
+		Arn:       arn,
+	}
+}
+
+func freezePolicy(arn Arn, strict bool, uvs ...*Universe) (ManagedPolicy, error) {
+	for _, uv := range uvs {
 		pol, ok := uv.Policy(arn)
 		if ok {
 			return *pol, nil
 		}
 	}
 
-	return ManagedPolicy{}, fmt.Errorf("cannot find policy with arn: %s", arn)
+	if strict {
+		return ManagedPolicy{}, fmt.Errorf("cannot find policy with arn: %s", arn)
+	} else {
+		return makeEmptyPolicy(arn), nil
+	}
 }
 
-func freezePolicies(arns []Arn, universes ...*Universe) ([]ManagedPolicy, error) {
+func freezePolicies(arns []Arn, strict bool, uvs ...*Universe) ([]ManagedPolicy, error) {
 	policies := make([]ManagedPolicy, len(arns))
 
 	for i, arn := range arns {
-		pol, err := freezePolicy(arn, universes...)
+		pol, err := freezePolicy(arn, strict, uvs...)
 		if err != nil {
 			return nil, err
 		}
@@ -312,11 +334,11 @@ func freezePolicies(arns []Arn, universes ...*Universe) ([]ManagedPolicy, error)
 	return policies, nil
 }
 
-func freezeGroupByArn(arn Arn, universes ...*Universe) (FrozenGroup, error) {
-	for _, uv := range universes {
+func freezeGroupByArn(arn Arn, strict bool, uvs ...*Universe) (FrozenGroup, error) {
+	for _, uv := range uvs {
 		grp, ok := uv.Group(arn)
 		if ok {
-			frozen, err := grp.FreezeWith(universes...)
+			frozen, err := grp.FreezeWith(strict, uvs...)
 			if err != nil {
 				return FrozenGroup{}, err
 			}
@@ -324,15 +346,18 @@ func freezeGroupByArn(arn Arn, universes ...*Universe) (FrozenGroup, error) {
 		}
 	}
 
-	return FrozenGroup{}, fmt.Errorf("cannot find group with arn: %s", arn)
-
+	if strict {
+		return FrozenGroup{}, fmt.Errorf("cannot find group with arn: %s", arn)
+	} else {
+		return makeEmptyGroup(arn), nil
+	}
 }
 
-func freezeGroupsByArn(arns []Arn, universes ...*Universe) ([]FrozenGroup, error) {
+func freezeGroupsByArn(arns []Arn, strict bool, uvs ...*Universe) ([]FrozenGroup, error) {
 	groups := make([]FrozenGroup, len(arns))
 
 	for i, arn := range arns {
-		grp, err := freezeGroupByArn(arn, universes...)
+		grp, err := freezeGroupByArn(arn, strict, uvs...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/entities/freeze_test.go
+++ b/pkg/entities/freeze_test.go
@@ -334,12 +334,12 @@ func TestFreeze(t *testing.T) {
 
 		var err error
 
-		out.fp, err = input.FrozenPrincipals(nil)
+		out.fp, err = input.FrozenPrincipals(true, nil)
 		if err != nil {
 			return output{}, err
 		}
 
-		out.fr, err = input.FrozenResources(nil)
+		out.fr, err = input.FrozenResources(true, nil)
 		if err != nil {
 			return output{}, err
 		}

--- a/pkg/entities/universe.go
+++ b/pkg/entities/universe.go
@@ -126,6 +126,14 @@ func (u *Universe) RemoveAccount(id string) {
 // Groups
 // -------------------------------------------------------------------------------------------------
 
+// normalizeGroupArn removes all path information from the group ARN, which is blatantly dishonest
+// but also required since some core AWS data sources provide only account + group name and omit any
+// other path information
+func normalizeGroupArn(arn Arn) Arn {
+	components := strings.Split(arn, "/")
+	return components[0] + "/" + components[len(components)-1]
+}
+
 // NumGroups returns the number of groups known to the universe
 func (u *Universe) NumGroups() int {
 	return len(u.groups)
@@ -153,12 +161,15 @@ func (u *Universe) HasGroup(arn Arn) bool {
 
 // Group attempts to retrieve the group based on its ARN
 func (u *Universe) Group(arn Arn) (*Group, bool) {
+	arn = normalizeGroupArn(arn)
 	g, ok := u.groups[arn]
 	return g, ok
 }
 
 // PutGroup saves the provided group into the universe, updating the definition if needed
 func (u *Universe) PutGroup(g Group) {
+	g.Arn = normalizeGroupArn(g.Arn)
+
 	u.mut.Lock()
 	defer u.mut.Unlock()
 
@@ -168,6 +179,8 @@ func (u *Universe) PutGroup(g Group) {
 
 // RemoveGroup removes the group referenced by the provided ARN
 func (u *Universe) RemoveGroup(arn Arn) {
+	arn = normalizeGroupArn(arn)
+
 	u.mut.Lock()
 	defer u.mut.Unlock()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/nsiow/yams/cmd/yams/cli"
 	v1 "github.com/nsiow/yams/pkg/server/api/v1"
 	"github.com/nsiow/yams/pkg/sim"
 )
@@ -14,16 +15,18 @@ type Server struct {
 
 	Sources   []*Source
 	Simulator *sim.Simulator
+	Opts      *cli.Flags
 }
 
-func NewServer(addr string) (*Server, error) {
+func NewServer(opts *cli.Flags) (*Server, error) {
 	mux := http.NewServeMux()
 	server := Server{
 		Server: &http.Server{
-			Addr:    addr,
+			Addr:    opts.Addr,
 			Handler: mux,
 		},
-		mux: mux,
+		mux:  mux,
+		Opts: opts,
 	}
 
 	sim, err := sim.NewSimulator()

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/nsiow/yams/internal/common"
 	"github.com/nsiow/yams/pkg/server/httputil"
@@ -21,6 +22,18 @@ func (s *Server) Status(w http.ResponseWriter, req *http.Request) {
 				"updated": src.Updated,
 			}
 		}),
+	}
+
+	env := make(map[string]string)
+	for _, key := range s.Opts.Env {
+		val := os.Getenv(key)
+		if len(val) > 0 {
+			env[key] = val
+		}
+	}
+
+	if len(env) > 0 {
+		status["env"] = env
 	}
 
 	httputil.WriteJsonResponse(w, req, status)

--- a/pkg/sim/options.go
+++ b/pkg/sim/options.go
@@ -33,6 +33,10 @@ type Options struct {
 	// matches
 	EnableFuzzyMatchArn bool
 
+	// Strict causes simulation to fail if it encounters an AWS managed policy or group that it cannot
+	// resolve. Otherwise, simulation will use an empty policy
+	Strict bool
+
 	// ForceFailure causes all simulation results to throw an error. Primarily used for testing and
 	// debugging purposes
 	ForceFailure bool
@@ -95,6 +99,13 @@ func WithEnableFuzzyMatchArn() OptionF {
 	}
 }
 
+// WithStrict enables failures for unknown managed policies and groups
+func WithStrict() OptionF {
+	return func(opt *Options) {
+		opt.Strict = true
+	}
+}
+
 // WithForceFailure causes all simulations to fail
 func WithForceFailure() OptionF {
 	return func(opt *Options) {
@@ -107,6 +118,7 @@ func WithForceFailure() OptionF {
 // the rules a bit for testing -- fewer checks around the specifics of the dummy resource calls we
 // use
 var TestingSimulationOptions = NewOptions(
-	WithSkipServiceAuthorizationValidation(),
+	WithStrict(),
 	WithTracing(),
+	WithSkipServiceAuthorizationValidation(),
 )

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -388,7 +388,7 @@ func (s *Simulator) Product(ps, as, rs []string, opts Options) ([]AccessTuple, e
 
 				if len(batch.Jobs) == s.Pool.BatchSize() {
 					s.Pool.Submit(batch)
-					batch = simBatch{Jobs: []simIn{}, Finished: finished}
+					batch = simBatch{Jobs: []simIn{}, Finished: finished, Done: &done}
 				}
 			}
 		}

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -415,11 +415,11 @@ func (s *Simulator) Product(ps, as, rs []string, opts Options) ([]AccessTuple, e
 					Resource:  job.Result.Resource,
 					Result:    job.Result})
 			}
-		case <-time.After(s.Pool.Timeout()):
-			return nil, fmt.Errorf("simulation unit timed out after %v; completed %d/%d jobs",
-				s.Pool.Timeout(), done.Load(), submitted)
+		case <-time.After(time.Second * 1):
+			break
 		}
 	}
 
+	close(finished)
 	return matrix, nil
 }

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -41,7 +41,7 @@ func (s *Simulator) resolvePrincipal(arn string, opts Options) (*entities.Frozen
 	for _, uv := range uvs {
 		principal, ok := uv.Principal(arn)
 		if ok {
-			fp, err := principal.FreezeWith(uvs...)
+			fp, err := principal.FreezeWith(opts.Strict, uvs...)
 			return &fp, err
 		}
 	}
@@ -77,7 +77,7 @@ func (s *Simulator) resolveResource(arn string, opts Options) (*entities.FrozenR
 	for _, uv := range uvs {
 		resource, ok := uv.Resource(arn)
 		if ok {
-			fr, err := resource.FreezeWith(uvs...)
+			fr, err := resource.FreezeWith(opts.Strict, uvs...)
 			return &fr, err
 		}
 	}

--- a/pkg/sim/sim_test.go
+++ b/pkg/sim/sim_test.go
@@ -249,10 +249,11 @@ func TestSimulateByArn(t *testing.T) {
 	testlib.RunTestSuite(t, tests, func(i input) (bool, error) {
 		sim, _ := NewSimulator()
 		sim.Universe = i.uv
-		res, err := sim.SimulateByArn(
+		res, err := sim.SimulateByArnWithOptions(
 			i.principalArn,
 			i.action,
 			i.resourceArn,
+			TestingSimulationOptions,
 		)
 		if err != nil {
 			return false, err

--- a/pkg/sim/simpool.go
+++ b/pkg/sim/simpool.go
@@ -63,13 +63,13 @@ func NewPool(ctx context.Context, simulator *Simulator) *Pool {
 
 func (p *Pool) NumWorkers() int {
 	if p.numWorkers == 0 {
+		p.numWorkers = runtime.NumCPU() // default to some reasonable number of workers
+
 		fromEnv := os.Getenv("YAMS_SIM_NUM_WORKERS")
 		num, err := strconv.Atoi(fromEnv)
 		if err == nil {
 			p.numWorkers = num
 		}
-
-		p.numWorkers = runtime.NumCPU() // default to some reasonable number of workers
 	}
 
 	return p.numWorkers
@@ -77,13 +77,13 @@ func (p *Pool) NumWorkers() int {
 
 func (p *Pool) BatchSize() int {
 	if p.batchSize == 0 {
+		p.batchSize = 1024 // default to some reasonable batch size
+
 		fromEnv := os.Getenv("YAMS_SIM_BATCH_SIZE")
 		num, err := strconv.Atoi(fromEnv)
 		if err == nil {
 			p.batchSize = num
 		}
-
-		p.batchSize = 1024 // default to some reasonable batch size
 	}
 
 	return p.batchSize
@@ -91,13 +91,13 @@ func (p *Pool) BatchSize() int {
 
 func (p *Pool) Timeout() time.Duration {
 	if p.timeout == 0 {
+		p.timeout = 60 * time.Second
+
 		fromEnv := os.Getenv("YAMS_SIM_TIMEOUT")
 		num, err := strconv.Atoi(fromEnv)
 		if err == nil {
 			p.timeout = time.Duration(num * int(time.Second))
 		}
-
-		p.timeout = 60 * time.Second
 	}
 
 	return p.timeout

--- a/pkg/sim/simpool.go
+++ b/pkg/sim/simpool.go
@@ -98,7 +98,7 @@ func (p *Pool) Timeout() time.Duration {
 			p.timeout = time.Duration(num * int(time.Second))
 		}
 
-		p.timeout = 30 * time.Second
+		p.timeout = 60 * time.Second
 	}
 
 	return p.timeout
@@ -138,7 +138,7 @@ func (p *Pool) startWorker() {
 func (p *Pool) handleBatch(b simBatch) {
 	for _, item := range b.Jobs {
 		result, err := p.Simulator.SimulateWithOptions(item.AuthContext, item.Options)
-		if result.IsAllowed {
+		if err != nil || result.IsAllowed {
 			out := simOut{Result: result, Error: err}
 			b.Finished <- out
 		}


### PR DESCRIPTION
### Overview

This PR catches `main` up to various feature branches following the `0.1.0` release, including:
- Proper handling of configuration overrides from the environment
- A simulation flag (off by default) for more strict handling of policy resolution: failing simulation if a policy cannot be resolved. This change inverts the default behavior to allow non-resolvable policies using the standard setup
- Support for echoing environment variables as part of the `/status` endpoint (server `-e/--env` flag)
- Avoid passing messages on channels for `!Allowed` actions to remove a bottleneck for massively parallel deployments; use atomic counters to measure progress instead of counting messages