### PR TITLE
fix: DynamoDBStore.List returns [] instead of nil on empty result

### DIFF
--- a/pkg/overlay/dynamodb.go
+++ b/pkg/overlay/dynamodb.go
@@ -231,7 +231,8 @@ func (s *DynamoDBStore) Delete(ctx context.Context, id string) error {
 // List returns summaries of all overlays, optionally filtered by a search query.
 func (s *DynamoDBStore) List(ctx context.Context, query string) ([]entities.OverlaySummary, error) {
 	query = strings.ToLower(query)
-	var summaries []entities.OverlaySummary
+	// Non-nil so the JSON API serializes an empty store as [] rather than null.
+	summaries := []entities.OverlaySummary{}
 	var lastKey map[string]types.AttributeValue
 
 	for {

--- a/pkg/overlay/dynamodb_test.go
+++ b/pkg/overlay/dynamodb_test.go
@@ -274,6 +274,36 @@ func TestDynamoDBStore_List(t *testing.T) {
 	}
 }
 
+func TestDynamoDBStore_List_EmptyIsNotNil(t *testing.T) {
+	// Ensure List returns a non-nil slice when no overlays exist; the JSON API
+	// otherwise serializes it as `null`, which breaks UI consumers that call
+	// list.sort / list.filter directly on the response.
+	client := newMockClient()
+	store := NewDynamoDBStoreWithClient(client, "test-table")
+	ctx := context.Background()
+
+	summaries, err := store.List(ctx, "")
+	if err != nil {
+		t.Fatalf("List on empty store failed: %v", err)
+	}
+	if summaries == nil {
+		t.Fatal("List returned a nil slice on empty store; expected []entities.OverlaySummary{}")
+	}
+	if len(summaries) != 0 {
+		t.Errorf("expected 0 summaries, got %d", len(summaries))
+	}
+
+	// Query miss on a non-empty store should also be non-nil.
+	_ = store.Create(ctx, entities.NewOverlay("alpha"))
+	summaries, err = store.List(ctx, "no-such-overlay")
+	if err != nil {
+		t.Fatalf("List with non-matching query failed: %v", err)
+	}
+	if summaries == nil {
+		t.Fatal("List returned a nil slice for a query that matched nothing")
+	}
+}
+
 func TestDynamoDBStore_Exists(t *testing.T) {
 	client := newMockClient()
 	store := NewDynamoDBStoreWithClient(client, "test-table")


### PR DESCRIPTION
When the overlay store is empty, `DynamoDBStore.List` returned a nil slice,
which Go's `encoding/json` serializes as `null`. UI code downstream calls
`list.sort(...)` directly on the parsed response and blows up with:

> Cannot read properties of null (reading 'sort')

`MemoryStore.List` already uses `make([]..., 0, len(...))` and doesn't hit
this. Align the DynamoDB path with a preallocated empty slice, and pin the
contract with a new test (`TestDynamoDBStore_List_EmptyIsNotNil`) that
covers both empty-store and query-with-no-matches.