### PR TITLE
Apply server-side shared context to simulations

### DIFF
--- a/cmd/yams/cli/completion.go
+++ b/cmd/yams/cli/completion.go
@@ -32,7 +32,7 @@ _yams() {
             fi
             ;;
         sim)
-            COMPREPLY=($(compgen -W "-s --server -p --principal -a --action -r --resource -c --context -o --overlay -x --exact -e --explain -t --trace" -- "${cur}"))
+            COMPREPLY=($(compgen -W "-s --server -p --principal -a --action -r --resource -c --context -o --overlay -x --exact --disable-shared-context -e --explain -t --trace" -- "${cur}"))
             ;;
         audit)
             COMPREPLY=($(compgen -W "-s --source -f --config -o --out -c --context --overlay" -- "${cur}"))
@@ -107,6 +107,7 @@ _yams() {
                         '*'{-c,--context}'[Context key=value]:context:' \
                         '*'{-o,--overlay}'[Overlay file]:file:_files' \
                         '(-x --exact)'{-x,--exact}'[Disable fuzzy matching]' \
+                        '--disable-shared-context[Disable server shared request context]' \
                         '(-e --explain)'{-e,--explain}'[Show explanation]' \
                         '(-t --trace)'{-t,--trace}'[Show trace]'
                     ;;

--- a/cmd/yams/cli/flags.go
+++ b/cmd/yams/cli/flags.go
@@ -67,16 +67,17 @@ type Flags struct {
 	Config string
 
 	// sim
-	Principal    string
-	Action       string
-	Resource     string
-	Context      MapString
-	MultiContext MapStringList
-	Explain      bool
-	Trace        bool
-	OverlayFiles MultiString
-	Overlay      v1.Overlay
-	Exact        bool
+	Principal            string
+	Action               string
+	Resource             string
+	Context              MapString
+	MultiContext         MapStringList
+	Explain              bool
+	Trace                bool
+	OverlayFiles         MultiString
+	Overlay              v1.Overlay
+	Exact                bool
+	DisableSharedContext bool
 
 	// multiple
 	Server    string
@@ -244,6 +245,9 @@ func Parse() (*Flags, error) {
 
 		fs.BoolVar(&opts.Exact, "x", false, "alias for -exact")
 		fs.BoolVar(&opts.Exact, "exact", false, "disable fuzzy-matching for ARNs")
+
+		fs.BoolVar(&opts.DisableSharedContext, "disable-shared-context", false,
+			"disable server shared request context for simulation")
 
 		fs.BoolVar(&opts.Explain, "e", false, "alias for -explain")
 		fs.BoolVar(&opts.Explain, "explain", false,

--- a/cmd/yams/sim/sim.go
+++ b/cmd/yams/sim/sim.go
@@ -46,15 +46,16 @@ func runSim(opts *cli.Flags) {
 	cli.PostReq(
 		cli.ApiUrl(opts.Server, "sim"),
 		v1.SimInput{
-			Principal:         opts.Principal,
-			Action:            opts.Action,
-			Resource:          opts.Resource,
-			Context:           opts.Context,
-			MultiValueContext: opts.MultiContext,
-			Fuzzy:             !opts.Exact,
-			Explain:           opts.Explain,
-			Trace:             opts.Trace,
-			Overlay:           opts.Overlay,
+			Principal:            opts.Principal,
+			Action:               opts.Action,
+			Resource:             opts.Resource,
+			Context:              opts.Context,
+			MultiValueContext:    opts.MultiContext,
+			DisableSharedContext: opts.DisableSharedContext,
+			Fuzzy:                !opts.Exact,
+			Explain:              opts.Explain,
+			Trace:                opts.Trace,
+			Overlay:              opts.Overlay,
 		},
 	)
 }
@@ -63,12 +64,13 @@ func runWhichPrincipals(opts *cli.Flags) {
 	cli.PostReq(
 		cli.ApiUrl(opts.Server, "sim", "whichPrincipals"),
 		v1.WhichPrincipalsInput{
-			Action:            opts.Action,
-			Resource:          opts.Resource,
-			Context:           opts.Context,
-			MultiValueContext: opts.MultiContext,
-			Overlay:           opts.Overlay,
-			Fuzzy:             !opts.Exact,
+			Action:               opts.Action,
+			Resource:             opts.Resource,
+			Context:              opts.Context,
+			MultiValueContext:    opts.MultiContext,
+			DisableSharedContext: opts.DisableSharedContext,
+			Overlay:              opts.Overlay,
+			Fuzzy:                !opts.Exact,
 		},
 	)
 }
@@ -77,12 +79,13 @@ func runWhichActions(opts *cli.Flags) {
 	cli.PostReq(
 		cli.ApiUrl(opts.Server, "sim", "whichActions"),
 		v1.WhichActionsInput{
-			Principal:         opts.Principal,
-			Resource:          opts.Resource,
-			Context:           opts.Context,
-			MultiValueContext: opts.MultiContext,
-			Overlay:           opts.Overlay,
-			Fuzzy:             !opts.Exact,
+			Principal:            opts.Principal,
+			Resource:             opts.Resource,
+			Context:              opts.Context,
+			MultiValueContext:    opts.MultiContext,
+			DisableSharedContext: opts.DisableSharedContext,
+			Overlay:              opts.Overlay,
+			Fuzzy:                !opts.Exact,
 		},
 	)
 }
@@ -91,12 +94,13 @@ func runWhichResources(opts *cli.Flags) {
 	cli.PostReq(
 		cli.ApiUrl(opts.Server, "sim", "whichResources"),
 		v1.WhichResourcesInput{
-			Principal:         opts.Principal,
-			Action:            opts.Action,
-			Context:           opts.Context,
-			MultiValueContext: opts.MultiContext,
-			Overlay:           opts.Overlay,
-			Fuzzy:             !opts.Exact,
+			Principal:            opts.Principal,
+			Action:               opts.Action,
+			Context:              opts.Context,
+			MultiValueContext:    opts.MultiContext,
+			DisableSharedContext: opts.DisableSharedContext,
+			Overlay:              opts.Overlay,
+			Fuzzy:                !opts.Exact,
 		},
 	)
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -345,6 +345,12 @@ curl ${YAMS_SERVER_ADDRESS}/api/v1/accounts/search/213
 ### Basic Simulation
 
 `POST /api/v1/sim`
+
+If the server was started with shared request context, those values are included in simulation
+requests by default for this endpoint and the extended simulation endpoints below. Request body
+`context` values override shared values on key conflicts. Set `"disableSharedContext": true` to run
+a simulation without server shared context.
+
 ```shell
 curl -X POST ${YAMS_SERVER_ADDRESS}/api/v1/sim -d '{
   "principal": "arn:aws:iam::777583092761:role/RedRole",

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -17,6 +17,10 @@ yams sim -p ... -a ... -r ... -c aws:SourceIp=10.0.0.1 -c aws:UserAgent=MyApp
 yams sim -p ... -a ... -r ... -c '{"aws:SourceIp": "10.0.0.1", "aws:UserAgent": "MyApp"}'
 ```
 
+When the server is started with shared request context via `yams server --context`, those values are
+included in all simulation operations by default. Request-specific context wins on key conflicts.
+Use `yams sim --disable-shared-context` to run a simulation without server shared context.
+
 ### Basic Simulation
 
 The most straightforward type of simulation is for a single request, providing all aspects of

--- a/pkg/server/api/v1/api_test.go
+++ b/pkg/server/api/v1/api_test.go
@@ -730,7 +730,6 @@ func TestGet_WithFreeze(t *testing.T) {
 	}
 }
 
-
 func TestSimRun_Allow(t *testing.T) {
 	api := newTestAPIWithData(t)
 
@@ -906,3 +905,195 @@ func TestWhichResources_ServerError(t *testing.T) {
 	}
 }
 
+func TestAPI_SharedContextAppliedToSimulationOperations(t *testing.T) {
+	api, principalArn, resourceArn := newTestAPIWithContextCondition(t)
+	api.SharedContext = map[string]string{"aws:SourceIp": "10.1.2.3"}
+
+	t.Run("sim run", func(t *testing.T) {
+		run := func(input SimInput) SimOutput {
+			body, _ := json.Marshal(input)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/v1/sim", bytes.NewReader(body))
+
+			api.SimRun(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("SimRun() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			var out SimOutput
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatalf("SimRun() invalid JSON: %v", err)
+			}
+			return out
+		}
+
+		baseInput := SimInput{
+			Principal: principalArn,
+			Action:    "s3:ListBucket",
+			Resource:  resourceArn,
+		}
+
+		if got := run(baseInput).Result; got != "ALLOW" {
+			t.Fatalf("SimRun() with shared context result = %s, want ALLOW", got)
+		}
+
+		disabledInput := baseInput
+		disabledInput.DisableSharedContext = true
+		if got := run(disabledInput).Result; got != "DENY" {
+			t.Fatalf("SimRun() with disabled shared context result = %s, want DENY", got)
+		}
+
+		overrideInput := baseInput
+		overrideInput.Context = map[string]string{"aws:SourceIp": "192.0.2.1"}
+		if got := run(overrideInput).Result; got != "DENY" {
+			t.Fatalf("SimRun() with request context override result = %s, want DENY", got)
+		}
+	})
+
+	t.Run("which principals", func(t *testing.T) {
+		run := func(input WhichPrincipalsInput) []string {
+			body, _ := json.Marshal(input)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/v1/sim/whichPrincipals", bytes.NewReader(body))
+
+			api.WhichPrincipals(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("WhichPrincipals() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			var out []string
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatalf("WhichPrincipals() invalid JSON: %v", err)
+			}
+			return out
+		}
+
+		baseInput := WhichPrincipalsInput{
+			Action:   "s3:ListBucket",
+			Resource: resourceArn,
+		}
+
+		if got := run(baseInput); !containsString(got, principalArn) {
+			t.Fatalf("WhichPrincipals() with shared context = %v, want %s", got, principalArn)
+		}
+
+		disabledInput := baseInput
+		disabledInput.DisableSharedContext = true
+		if got := run(disabledInput); containsString(got, principalArn) {
+			t.Fatalf("WhichPrincipals() with disabled shared context = %v, want no %s", got, principalArn)
+		}
+	})
+
+	t.Run("which actions", func(t *testing.T) {
+		run := func(input WhichActionsInput) []string {
+			body, _ := json.Marshal(input)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/v1/sim/whichActions", bytes.NewReader(body))
+
+			api.WhichActions(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("WhichActions() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			var out []string
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatalf("WhichActions() invalid JSON: %v", err)
+			}
+			return out
+		}
+
+		baseInput := WhichActionsInput{
+			Principal: principalArn,
+			Resource:  resourceArn,
+		}
+
+		if got := run(baseInput); !containsString(got, "s3:ListBucket") {
+			t.Fatalf("WhichActions() with shared context = %v, want s3:ListBucket", got)
+		}
+
+		disabledInput := baseInput
+		disabledInput.DisableSharedContext = true
+		if got := run(disabledInput); containsString(got, "s3:ListBucket") {
+			t.Fatalf("WhichActions() with disabled shared context = %v, want no s3:ListBucket", got)
+		}
+	})
+
+	t.Run("which resources", func(t *testing.T) {
+		run := func(input WhichResourcesInput) []string {
+			body, _ := json.Marshal(input)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/api/v1/sim/whichResources", bytes.NewReader(body))
+
+			api.WhichResources(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("WhichResources() status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			var out []string
+			if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+				t.Fatalf("WhichResources() invalid JSON: %v", err)
+			}
+			return out
+		}
+
+		baseInput := WhichResourcesInput{
+			Principal: principalArn,
+			Action:    "s3:ListBucket",
+		}
+
+		if got := run(baseInput); !containsString(got, resourceArn) {
+			t.Fatalf("WhichResources() with shared context = %v, want %s", got, resourceArn)
+		}
+
+		disabledInput := baseInput
+		disabledInput.DisableSharedContext = true
+		if got := run(disabledInput); containsString(got, resourceArn) {
+			t.Fatalf("WhichResources() with disabled shared context = %v, want no %s", got, resourceArn)
+		}
+	})
+}
+
+func newTestAPIWithContextCondition(t *testing.T) (*API, string, string) {
+	t.Helper()
+
+	api := newTestAPI(t)
+	principalArn := "arn:aws:iam::123456789012:user/contextuser"
+	resourceArn := "arn:aws:s3:::context-bucket"
+
+	api.Simulator.Universe.PutPrincipal(entities.Principal{
+		Arn:       principalArn,
+		AccountId: "123456789012",
+		InlinePolicies: []policy.Policy{
+			{
+				Statement: []policy.Statement{
+					{
+						Effect:   policy.EFFECT_ALLOW,
+						Action:   policy.NewValue("s3:ListBucket"),
+						Resource: policy.NewValue(resourceArn),
+						Condition: policy.ConditionBlock{
+							"IpAddress": policy.ConditionValues{
+								"aws:SourceIp": policy.NewValue("10.0.0.0/8"),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	api.Simulator.Universe.PutResource(entities.Resource{
+		Arn:       resourceArn,
+		Type:      "AWS::S3::Bucket",
+		AccountId: "123456789012",
+	})
+
+	return api, principalArn, resourceArn
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/server/api/v1/context.go
+++ b/pkg/server/api/v1/context.go
@@ -1,0 +1,16 @@
+package v1
+
+func (api *API) requestContext(input map[string]string, disableSharedContext bool) map[string]string {
+	if disableSharedContext || len(api.SharedContext) == 0 {
+		return input
+	}
+
+	ctx := make(map[string]string, len(api.SharedContext)+len(input))
+	for k, v := range api.SharedContext {
+		ctx[k] = v
+	}
+	for k, v := range input {
+		ctx[k] = v
+	}
+	return ctx
+}

--- a/pkg/server/api/v1/sim.go
+++ b/pkg/server/api/v1/sim.go
@@ -15,11 +15,12 @@ import (
 // -------------------------------------------------------------------------------------------------
 
 type SimInput struct {
-	Principal         string              `json:"principal"`
-	Action            string              `json:"action"`
-	Resource          string              `json:"resource"`
-	Context           map[string]string   `json:"context"`
-	MultiValueContext map[string][]string `json:"multiValueContext"`
+	Principal            string              `json:"principal"`
+	Action               string              `json:"action"`
+	Resource             string              `json:"resource"`
+	Context              map[string]string   `json:"context"`
+	MultiValueContext    map[string][]string `json:"multiValueContext"`
+	DisableSharedContext bool                `json:"disableSharedContext"`
 
 	Fuzzy   bool    `json:"fuzzy"`
 	Explain bool    `json:"explain"`
@@ -61,8 +62,9 @@ func (api *API) SimRun(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// construct options
+	requestContext := api.requestContext(input.Context, input.DisableSharedContext)
 	opts := sim.NewOptions(
-		sim.WithAdditionalProperties(input.Context),
+		sim.WithAdditionalProperties(requestContext),
 		sim.WithAdditionalMultiValueProperties(input.MultiValueContext),
 	)
 	opts.EnableTracing = input.Explain || input.Trace
@@ -101,7 +103,7 @@ func (api *API) SimRun(w http.ResponseWriter, req *http.Request) {
 		"principal", input.Principal,
 		"action", input.Action,
 		"resource", input.Resource,
-		"context", input.Context,
+		"context", requestContext,
 		"result", out.Result)
 	httputil.WriteJsonResponse(w, req, out)
 }

--- a/pkg/server/api/v1/which_actions.go
+++ b/pkg/server/api/v1/which_actions.go
@@ -14,10 +14,11 @@ import (
 // -------------------------------------------------------------------------------------------------
 
 type WhichActionsInput struct {
-	Principal         string              `json:"principal"`
-	Resource          string              `json:"resource"`
-	Context           map[string]string   `json:"context"`
-	MultiValueContext map[string][]string `json:"multiValueContext"`
+	Principal            string              `json:"principal"`
+	Resource             string              `json:"resource"`
+	Context              map[string]string   `json:"context"`
+	MultiValueContext    map[string][]string `json:"multiValueContext"`
+	DisableSharedContext bool                `json:"disableSharedContext"`
 
 	Overlay Overlay `json:"overlay"`
 
@@ -39,8 +40,9 @@ func (api *API) WhichActions(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	requestContext := api.requestContext(input.Context, input.DisableSharedContext)
 	opts := sim.NewOptions(
-		sim.WithAdditionalProperties(input.Context),
+		sim.WithAdditionalProperties(requestContext),
 		sim.WithAdditionalMultiValueProperties(input.MultiValueContext),
 	)
 	opts.Overlay = input.Overlay.Universe()

--- a/pkg/server/api/v1/which_principals.go
+++ b/pkg/server/api/v1/which_principals.go
@@ -14,10 +14,11 @@ import (
 // -------------------------------------------------------------------------------------------------
 
 type WhichPrincipalsInput struct {
-	Action            string              `json:"action"`
-	Resource          string              `json:"resource"`
-	Context           map[string]string   `json:"context"`
-	MultiValueContext map[string][]string `json:"multiValueContext"`
+	Action               string              `json:"action"`
+	Resource             string              `json:"resource"`
+	Context              map[string]string   `json:"context"`
+	MultiValueContext    map[string][]string `json:"multiValueContext"`
+	DisableSharedContext bool                `json:"disableSharedContext"`
 
 	Overlay Overlay `json:"overlay"`
 
@@ -44,8 +45,9 @@ func (api *API) WhichPrincipals(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	requestContext := api.requestContext(input.Context, input.DisableSharedContext)
 	opts := sim.NewOptions(
-		sim.WithAdditionalProperties(input.Context),
+		sim.WithAdditionalProperties(requestContext),
 		sim.WithAdditionalMultiValueProperties(input.MultiValueContext),
 	)
 	opts.Overlay = input.Overlay.Universe()

--- a/pkg/server/api/v1/which_resources.go
+++ b/pkg/server/api/v1/which_resources.go
@@ -14,10 +14,11 @@ import (
 // -------------------------------------------------------------------------------------------------
 
 type WhichResourcesInput struct {
-	Principal         string              `json:"principal"`
-	Action            string              `json:"action"`
-	Context           map[string]string   `json:"context"`
-	MultiValueContext map[string][]string `json:"multiValueContext"`
+	Principal            string              `json:"principal"`
+	Action               string              `json:"action"`
+	Context              map[string]string   `json:"context"`
+	MultiValueContext    map[string][]string `json:"multiValueContext"`
+	DisableSharedContext bool                `json:"disableSharedContext"`
 
 	Overlay Overlay `json:"overlay"`
 
@@ -44,8 +45,9 @@ func (api *API) WhichResources(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	requestContext := api.requestContext(input.Context, input.DisableSharedContext)
 	opts := sim.NewOptions(
-		sim.WithAdditionalProperties(input.Context),
+		sim.WithAdditionalProperties(requestContext),
 		sim.WithAdditionalMultiValueProperties(input.MultiValueContext),
 	)
 	opts.Overlay = input.Overlay.Universe()

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -129,6 +129,7 @@ export interface SimulationRequest {
   action: string;
   resource: string;
   context?: Record<string, string>;
+  disableSharedContext?: boolean;
   fuzzy?: boolean;
   explain?: boolean;
   trace?: boolean;
@@ -156,6 +157,7 @@ export interface WhichPrincipalsRequest {
   action: string;
   resource?: string;
   context?: Record<string, string>;
+  disableSharedContext?: boolean;
   overlay?: SimulationOverlay;
   fuzzy?: boolean;
 }
@@ -164,6 +166,7 @@ export interface WhichResourcesRequest {
   principal: string;
   action?: string;
   context?: Record<string, string>;
+  disableSharedContext?: boolean;
   overlay?: SimulationOverlay;
   fuzzy?: boolean;
 }
@@ -172,6 +175,7 @@ export interface WhichActionsRequest {
   principal: string;
   resource: string;
   context?: Record<string, string>;
+  disableSharedContext?: boolean;
   overlay?: SimulationOverlay;
   fuzzy?: boolean;
 }

--- a/ui/src/pages/config.tsx
+++ b/ui/src/pages/config.tsx
@@ -1,26 +1,13 @@
 // ui/src/pages/config.tsx
-import { useState } from 'react';
 import {
   Box,
   Card,
   Stack,
-  Switch,
   Text,
   Title,
 } from '@mantine/core';
 
-const SHARED_CONTEXT_KEY = 'yams.enable_shared_request_context';
-
 export function ConfigPage(): JSX.Element {
-  const [enabled, setEnabled] = useState<boolean>(
-    () => localStorage.getItem(SHARED_CONTEXT_KEY) === 'true'
-  );
-
-  const handleToggle = (checked: boolean): void => {
-    setEnabled(checked);
-    localStorage.setItem(SHARED_CONTEXT_KEY, String(checked));
-  };
-
   return (
     <Box p="md">
       <Stack gap="lg">
@@ -33,12 +20,10 @@ export function ConfigPage(): JSX.Element {
 
         <Card withBorder p="lg">
           <Title order={5} mb="md">Shared Request Context</Title>
-          <Switch
-            label="Enable shared request context"
-            description="When enabled, context key-value pairs configured by the server operator are automatically included in all simulation panes. User-defined context variables take precedence on key conflicts."
-            checked={enabled}
-            onChange={(e) => handleToggle(e.currentTarget.checked)}
-          />
+          <Text size="sm" c="dimmed">
+            Server-configured request context is included in simulation requests by default.
+            Request-specific context values take precedence on key conflicts.
+          </Text>
         </Card>
       </Stack>
     </Box>

--- a/ui/src/pages/shared-variables.tsx
+++ b/ui/src/pages/shared-variables.tsx
@@ -1,8 +1,6 @@
 // ui/src/pages/shared-variables.tsx
 import { useEffect, useState } from 'react';
 import {
-  Anchor,
-  Badge,
   Box,
   Card,
   Group,
@@ -12,16 +10,12 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { Link } from 'react-router-dom';
 import { yamsApi } from '../lib/api';
-
-const SHARED_CONTEXT_KEY = 'yams.enable_shared_request_context';
 
 export function SharedVariablesPage(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [variables, setVariables] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
-  const enabled = localStorage.getItem(SHARED_CONTEXT_KEY) === 'true';
 
   useEffect(() => {
     yamsApi.sharedContext()
@@ -44,24 +38,9 @@ export function SharedVariablesPage(): JSX.Element {
           <Title order={3} mb={4}>Shared Variables</Title>
           <Text size="sm" c="dimmed">
             Request context variables configured by the server operator via <Text component="span" ff="monospace" fw={500}>-c</Text> flags.
-            When enabled, these are automatically included in all simulation panes.
+            These are included in simulation requests by default.
           </Text>
         </Box>
-
-        {/* Feature status */}
-        <Card withBorder p="lg">
-          <Group justify="space-between" align="center">
-            <Group gap="xs" align="center">
-              <Badge color={enabled ? 'green' : 'red'} size="xs" circle />
-              <Text size="sm" fw={500}>
-                Shared request context is {enabled ? 'enabled' : 'disabled'}
-              </Text>
-            </Group>
-            <Anchor component={Link} to="/config" size="sm">
-              {enabled ? 'Manage in Config' : 'Enable in Config'}
-            </Anchor>
-          </Group>
-        </Card>
 
         {/* Variables table */}
         <Card withBorder p="lg">

--- a/ui/src/pages/simulate/access.tsx
+++ b/ui/src/pages/simulate/access.tsx
@@ -950,21 +950,11 @@ export function AccessCheckPage(): JSX.Element {
   const contextVarsRef = useRef(contextVars);
   contextVarsRef.current = contextVars;
 
-  // Build context object from key-value pairs, merging shared context
-  const sharedContextRef = useRef(sharedContextVars);
-  sharedContextRef.current = sharedContextVars;
-
+  // Build context object from user-provided key-value pairs.
+  // Shared context is displayed by the UI but applied by the server.
   const buildContext = (): Record<string, string> | undefined => {
     const result: Record<string, string> = {};
 
-    // Shared vars first
-    for (const cv of sharedContextRef.current) {
-      const k = cv.key.trim();
-      const v = cv.value.trim();
-      if (k && v) result[k] = v;
-    }
-
-    // User vars override
     for (const cv of contextVarsRef.current) {
       const k = cv.key.trim();
       const v = cv.value.trim();

--- a/ui/src/pages/simulate/shared/context-editor.test.ts
+++ b/ui/src/pages/simulate/shared/context-editor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildContext } from './context-editor';
+
+describe('buildContext', () => {
+  it('serializes user-provided context', () => {
+    expect(buildContext([
+      { key: 'aws:RequestTag/team', value: 'security' },
+      { key: ' ', value: 'ignored' },
+    ])).toEqual({
+      'aws:RequestTag/team': 'security',
+    });
+  });
+
+  it('returns undefined when no user context is set', () => {
+    expect(buildContext([])).toBeUndefined();
+  });
+});

--- a/ui/src/pages/simulate/shared/context-editor.tsx
+++ b/ui/src/pages/simulate/shared/context-editor.tsx
@@ -135,24 +135,13 @@ export function ContextEditor({
   );
 }
 
-// Helper to build context object from key-value pairs, with optional shared context merged in.
-// Shared vars are included first, then user vars override on key conflict.
+// Helper to build context object from user-provided key-value pairs.
+// Shared context is displayed by the UI but applied by the server.
 export function buildContext(
   contextVars: ContextVariable[],
-  sharedVars?: ContextVariable[],
 ): Record<string, string> | undefined {
   const result: Record<string, string> = {};
 
-  // Shared vars first
-  if (sharedVars) {
-    for (const cv of sharedVars) {
-      const k = cv.key.trim();
-      const v = cv.value.trim();
-      if (k && v) result[k] = v;
-    }
-  }
-
-  // User vars override
   for (const cv of contextVars) {
     const k = cv.key.trim();
     const v = cv.value.trim();

--- a/ui/src/pages/simulate/shared/use-shared-context.ts
+++ b/ui/src/pages/simulate/shared/use-shared-context.ts
@@ -3,18 +3,11 @@ import { useEffect, useState } from 'react';
 import { yamsApi } from '../../../lib/api';
 import type { ContextVariable } from './context-editor';
 
-const SHARED_CONTEXT_KEY = 'yams.enable_shared_request_context';
-
-// Fetches shared context from the server if the user has opted in via localStorage.
+// Fetches shared context from the server for display alongside user-provided context.
 export function useSharedContext(): ContextVariable[] {
   const [sharedVars, setSharedVars] = useState<ContextVariable[]>([]);
 
   useEffect(() => {
-    if (localStorage.getItem(SHARED_CONTEXT_KEY) !== 'true') {
-      setSharedVars([]);
-      return;
-    }
-
     yamsApi.sharedContext()
       .then((ctx) => {
         setSharedVars(

--- a/ui/src/pages/simulate/which-actions.test.tsx
+++ b/ui/src/pages/simulate/which-actions.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../lib/api', () => ({
     searchResources: vi.fn(),
     whichActions: vi.fn(),
     simulate: vi.fn(),
+    sharedContext: vi.fn(),
     listOverlays: vi.fn(),
     getOverlay: vi.fn(),
   },
@@ -42,6 +43,7 @@ describe('WhichActionsPage', () => {
     vi.mocked(yamsApi.accountNames).mockResolvedValue(mockAccountNames);
     vi.mocked(yamsApi.resourceAccounts).mockResolvedValue(mockResourceAccounts);
     vi.mocked(yamsApi.actionAccessLevels).mockResolvedValue(mockActionAccessLevels);
+    vi.mocked(yamsApi.sharedContext).mockResolvedValue({});
     vi.mocked(yamsApi.listOverlays).mockResolvedValue([]);
   });
 

--- a/ui/src/pages/simulate/which-actions.tsx
+++ b/ui/src/pages/simulate/which-actions.tsx
@@ -129,8 +129,6 @@ export function WhichActionsPage(): JSX.Element {
   // Use refs for context vars to avoid triggering effect
   const contextVarsRef = useRef(contextVars);
   contextVarsRef.current = contextVars;
-  const sharedContextRef = useRef(sharedContextVars);
-  sharedContextRef.current = sharedContextVars;
 
   // Search functions
   const searchPrincipals = useCallback((query: string) => yamsApi.searchPrincipals(query), []);
@@ -149,7 +147,7 @@ export function WhichActionsPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.whichActions({
         principal: selectedPrincipal,
@@ -219,7 +217,7 @@ export function WhichActionsPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.simulate({
         principal: selectedPrincipal!,

--- a/ui/src/pages/simulate/which-principals.test.tsx
+++ b/ui/src/pages/simulate/which-principals.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../lib/api', () => ({
     searchResources: vi.fn(),
     whichPrincipals: vi.fn(),
     simulate: vi.fn(),
+    sharedContext: vi.fn(),
     listOverlays: vi.fn(),
     getOverlay: vi.fn(),
   },
@@ -40,6 +41,7 @@ describe('WhichPrincipalsPage', () => {
     vi.mocked(yamsApi.accountNames).mockResolvedValue(mockAccountNames);
     vi.mocked(yamsApi.resourceAccounts).mockResolvedValue(mockResourceAccounts);
     vi.mocked(yamsApi.actionAccessLevels).mockResolvedValue(mockActionAccessLevels);
+    vi.mocked(yamsApi.sharedContext).mockResolvedValue({});
     vi.mocked(yamsApi.listOverlays).mockResolvedValue([]);
   });
 

--- a/ui/src/pages/simulate/which-principals.tsx
+++ b/ui/src/pages/simulate/which-principals.tsx
@@ -132,8 +132,6 @@ export function WhichPrincipalsPage(): JSX.Element {
   // Use refs for context vars to avoid triggering effect
   const contextVarsRef = useRef(contextVars);
   contextVarsRef.current = contextVars;
-  const sharedContextRef = useRef(sharedContextVars);
-  sharedContextRef.current = sharedContextVars;
 
   // Check if current action is a resource creation action
   const isCreationAction = useMemo(() => {
@@ -163,7 +161,7 @@ export function WhichPrincipalsPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.whichPrincipals({
         action: selectedAction,
@@ -233,7 +231,7 @@ export function WhichPrincipalsPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.simulate({
         principal,

--- a/ui/src/pages/simulate/which-resources.test.tsx
+++ b/ui/src/pages/simulate/which-resources.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../lib/api', () => ({
     searchActions: vi.fn(),
     whichResources: vi.fn(),
     simulate: vi.fn(),
+    sharedContext: vi.fn(),
     listOverlays: vi.fn(),
     getOverlay: vi.fn(),
   },
@@ -41,6 +42,7 @@ describe('WhichResourcesPage', () => {
     vi.mocked(yamsApi.accountNames).mockResolvedValue(mockAccountNames);
     vi.mocked(yamsApi.resourceAccounts).mockResolvedValue(mockResourceAccounts);
     vi.mocked(yamsApi.actionAccessLevels).mockResolvedValue(mockActionAccessLevels);
+    vi.mocked(yamsApi.sharedContext).mockResolvedValue({});
     vi.mocked(yamsApi.listOverlays).mockResolvedValue([]);
   });
 

--- a/ui/src/pages/simulate/which-resources.tsx
+++ b/ui/src/pages/simulate/which-resources.tsx
@@ -130,8 +130,6 @@ export function WhichResourcesPage(): JSX.Element {
   // Use refs for context vars to avoid triggering effect
   const contextVarsRef = useRef(contextVars);
   contextVarsRef.current = contextVars;
-  const sharedContextRef = useRef(sharedContextVars);
-  sharedContextRef.current = sharedContextVars;
 
   // Search functions
   const searchPrincipals = useCallback((query: string) => yamsApi.searchPrincipals(query), []);
@@ -150,7 +148,7 @@ export function WhichResourcesPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.whichResources({
         principal: selectedPrincipal,
@@ -220,7 +218,7 @@ export function WhichResourcesPage(): JSX.Element {
 
     try {
       const overlay = buildCombinedOverlay(selectedOverlayIds, loadedOverlays);
-      const context = buildContext(contextVarsRef.current, sharedContextRef.current);
+      const context = buildContext(contextVarsRef.current);
 
       const response = await yamsApi.simulate({
         principal: selectedPrincipal!,


### PR DESCRIPTION
### Overview

Currently, server-side shared context is implicitly sent on every simulation done via the UI, but doesn't take into account simulation requests submitted the API

This PR standardizes the two modes so that request context is always sent, with:
* a browser-local setting to disable it via the UI
* and a flag/API parameter to disable it via the API