### PR TITLE
feat: Logical groupings for audit functionality

### DIFF
--- a/cmd/yams/audit/audit.go
+++ b/cmd/yams/audit/audit.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime/debug"
 	"runtime/pprof"
+	"sort"
 	"strings"
 
 	"github.com/nsiow/yams/cmd/yams/cli"
@@ -18,10 +19,35 @@ import (
 	"github.com/nsiow/yams/pkg/sim"
 )
 
-// ConfigEntry defines a resource type and the actions to audit against it
+const (
+	formatCSV          = "csv"
+	formatGroupedCSV   = "grouped-csv"
+	formatGroupedJSONL = "grouped-jsonl"
+)
+
+// ActionGroup maps a set of concrete AWS actions to a logical access group.
+type ActionGroup struct {
+	Name    string   `json:"name"`
+	Actions []string `json:"actions"`
+}
+
+// ConfigEntry defines a resource type and either actions or logical action groups to audit.
 type ConfigEntry struct {
-	ResourceType string   `json:"resource_type"`
-	Actions      []string `json:"actions"`
+	ResourceType string        `json:"resource_type"`
+	Actions      []string      `json:"actions,omitempty"`
+	ActionGroups []ActionGroup `json:"action_groups,omitempty"`
+}
+
+func (e ConfigEntry) allActions() []string {
+	if len(e.Actions) > 0 {
+		return e.Actions
+	}
+
+	var actions []string
+	for _, group := range e.ActionGroups {
+		actions = append(actions, group.Actions...)
+	}
+	return actions
 }
 
 // Run executes the audit subcommand
@@ -57,6 +83,9 @@ func Run(opts *cli.Flags) {
 	if err != nil {
 		cli.Fail("error loading config: %v", err)
 	}
+	if err := validateOutputOptions(opts, config); err != nil {
+		cli.Fail("error validating audit output: %v", err)
+	}
 
 	simulator, err := buildSimulator(opts.Sources)
 	if err != nil {
@@ -83,6 +112,9 @@ func Run(opts *cli.Flags) {
 
 	// Pre-freeze all principals once (reused across all config entries)
 	allPrincipalArns := simulator.Universe.PrincipalArns()
+	if opts.Format != formatCSV {
+		sort.Strings(allPrincipalArns)
+	}
 	slog.Info("freezing principals", "count", len(allPrincipalArns))
 
 	frozenPrincipals, err := simulator.FreezePrincipals(allPrincipalArns, sopts)
@@ -95,29 +127,67 @@ func Run(opts *cli.Flags) {
 	if err != nil {
 		cli.Fail("error opening output: %v", err)
 	}
-	defer w.Close()
-
-	cw := csv.NewWriter(w)
-	defer cw.Flush()
-
-	if err := cw.Write([]string{"resource", "action", "principal"}); err != nil {
-		cli.Fail("error writing CSV header: %v", err)
-	}
 
 	slog.Info("audit starting",
 		"principals", len(frozenPrincipals),
-		"entries", len(config))
+		"entries", len(config),
+		"format", opts.Format)
 
-	var totalRows int
+	if opts.Format == formatCSV {
+		cw := csv.NewWriter(w)
+		if err := cw.Write([]string{"resource", "action", "principal"}); err != nil {
+			cli.Fail("error writing CSV header: %v", err)
+		}
+
+		var totalRows int
+		for i, entry := range config {
+			entry.Actions = entry.allActions()
+			n, err := processEntry(simulator, frozenPrincipals, entry, sopts, cw)
+			if err != nil {
+				cli.Fail("error processing entry %d (%s): %v", i, entry.ResourceType, err)
+			}
+			totalRows += n
+		}
+		cw.Flush()
+		if err := cw.Error(); err != nil {
+			cli.Fail("error flushing CSV output: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			cli.Fail("error closing audit output: %v", err)
+		}
+		slog.Info("audit complete", "rows", totalRows)
+		return
+	}
+
+	gw, err := newGroupedWriter(opts.Format, w)
+	if err != nil {
+		cli.Fail("error creating grouped output writer: %v", err)
+	}
+
+	var totalGroups, totalRelationships int
 	for i, entry := range config {
-		n, err := processEntry(simulator, frozenPrincipals, entry, sopts, cw)
+		groups, relationships, err := processGroupedEntry(
+			simulator,
+			frozenPrincipals,
+			entry,
+			sopts,
+			opts.ResourceBatchSize,
+			gw,
+		)
 		if err != nil {
 			cli.Fail("error processing entry %d (%s): %v", i, entry.ResourceType, err)
 		}
-		totalRows += n
+		totalGroups += groups
+		totalRelationships += relationships
+	}
+	if err := gw.Flush(); err != nil {
+		cli.Fail("error flushing grouped output: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		cli.Fail("error closing audit output: %v", err)
 	}
 
-	slog.Info("audit complete", "rows", totalRows)
+	slog.Info("audit complete", "groups", totalGroups, "relationships", totalRelationships)
 }
 
 // loadConfig reads and parses the audit config JSON file
@@ -142,12 +212,85 @@ func loadConfig(path string) ([]ConfigEntry, error) {
 		if entry.ResourceType == "" {
 			return nil, fmt.Errorf("entry %d: missing resource_type", i)
 		}
-		if len(entry.Actions) == 0 {
-			return nil, fmt.Errorf("entry %d (%s): missing actions", i, entry.ResourceType)
+		if (len(entry.Actions) == 0) == (len(entry.ActionGroups) == 0) {
+			return nil, fmt.Errorf(
+				"entry %d (%s): must supply exactly one of actions or action_groups",
+				i,
+				entry.ResourceType,
+			)
+		}
+
+		groupNames := make(map[string]struct{})
+		actionNames := make(map[string]string)
+		for j, group := range entry.ActionGroups {
+			if group.Name == "" {
+				return nil, fmt.Errorf(
+					"entry %d (%s): action group %d is missing name",
+					i,
+					entry.ResourceType,
+					j,
+				)
+			}
+			if len(group.Actions) == 0 {
+				return nil, fmt.Errorf(
+					"entry %d (%s): action group %q is missing actions",
+					i,
+					entry.ResourceType,
+					group.Name,
+				)
+			}
+			if _, ok := groupNames[group.Name]; ok {
+				return nil, fmt.Errorf(
+					"entry %d (%s): duplicate action group %q",
+					i,
+					entry.ResourceType,
+					group.Name,
+				)
+			}
+			groupNames[group.Name] = struct{}{}
+
+			for _, action := range group.Actions {
+				actionKey := strings.ToLower(action)
+				if previousGroup, ok := actionNames[actionKey]; ok {
+					return nil, fmt.Errorf(
+						"entry %d (%s): action %q belongs to both %q and %q",
+						i,
+						entry.ResourceType,
+						action,
+						previousGroup,
+						group.Name,
+					)
+				}
+				actionNames[actionKey] = group.Name
+			}
 		}
 	}
 
 	return config, nil
+}
+
+func validateOutputOptions(opts *cli.Flags, config []ConfigEntry) error {
+	switch opts.Format {
+	case formatCSV:
+		return nil
+	case formatGroupedCSV, formatGroupedJSONL:
+		if opts.ResourceBatchSize <= 0 {
+			return fmt.Errorf("resource-batch-size must be greater than zero")
+		}
+		for i, entry := range config {
+			if len(entry.ActionGroups) == 0 {
+				return fmt.Errorf(
+					"entry %d (%s): %s output requires action_groups",
+					i,
+					entry.ResourceType,
+					opts.Format,
+				)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %q", opts.Format)
+	}
 }
 
 // buildSimulator creates a Simulator with data loaded from the specified sources

--- a/cmd/yams/audit/audit.go
+++ b/cmd/yams/audit/audit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nsiow/yams/cmd/yams/cli"
 	"github.com/nsiow/yams/internal/smartrw"
+	"github.com/nsiow/yams/pkg/aws/sar"
 	"github.com/nsiow/yams/pkg/entities"
 	"github.com/nsiow/yams/pkg/server"
 	"github.com/nsiow/yams/pkg/sim"
@@ -208,7 +209,8 @@ func loadConfig(path string) ([]ConfigEntry, error) {
 		return nil, fmt.Errorf("unable to parse config: %w", err)
 	}
 
-	for i, entry := range config {
+	for i := range config {
+		entry := &config[i]
 		if entry.ResourceType == "" {
 			return nil, fmt.Errorf("entry %d: missing resource_type", i)
 		}
@@ -220,9 +222,21 @@ func loadConfig(path string) ([]ConfigEntry, error) {
 			)
 		}
 
+		if len(entry.Actions) > 0 {
+			for j, action := range entry.Actions {
+				canonical, err := canonicalAction(action)
+				if err != nil {
+					return nil, fmt.Errorf("entry %d (%s): %w", i, entry.ResourceType, err)
+				}
+				entry.Actions[j] = canonical
+			}
+			continue
+		}
+
 		groupNames := make(map[string]struct{})
 		actionNames := make(map[string]string)
-		for j, group := range entry.ActionGroups {
+		for j := range entry.ActionGroups {
+			group := &entry.ActionGroups[j]
 			if group.Name == "" {
 				return nil, fmt.Errorf(
 					"entry %d (%s): action group %d is missing name",
@@ -249,24 +263,45 @@ func loadConfig(path string) ([]ConfigEntry, error) {
 			}
 			groupNames[group.Name] = struct{}{}
 
-			for _, action := range group.Actions {
-				actionKey := strings.ToLower(action)
-				if previousGroup, ok := actionNames[actionKey]; ok {
+			for k, action := range group.Actions {
+				canonical, err := canonicalAction(action)
+				if err != nil {
+					return nil, fmt.Errorf("entry %d (%s): %w", i, entry.ResourceType, err)
+				}
+				if previousGroup, ok := actionNames[canonical]; ok {
+					if previousGroup == group.Name {
+						return nil, fmt.Errorf(
+							"entry %d (%s): duplicate action %q in action group %q",
+							i,
+							entry.ResourceType,
+							canonical,
+							group.Name,
+						)
+					}
 					return nil, fmt.Errorf(
 						"entry %d (%s): action %q belongs to both %q and %q",
 						i,
 						entry.ResourceType,
-						action,
+						canonical,
 						previousGroup,
 						group.Name,
 					)
 				}
-				actionNames[actionKey] = group.Name
+				actionNames[canonical] = group.Name
+				group.Actions[k] = canonical
 			}
 		}
 	}
 
 	return config, nil
+}
+
+func canonicalAction(action string) (string, error) {
+	resolved, ok := sar.LookupString(action)
+	if !ok {
+		return "", fmt.Errorf("unknown action %q", action)
+	}
+	return resolved.ShortName(), nil
 }
 
 func validateOutputOptions(opts *cli.Flags, config []ConfigEntry) error {

--- a/cmd/yams/audit/audit_test.go
+++ b/cmd/yams/audit/audit_test.go
@@ -1,0 +1,151 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nsiow/yams/cmd/yams/cli"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "legacy actions",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","actions":["sqs:ReceiveMessage"]}
+			]`,
+		},
+		{
+			name: "action groups",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ","actions":["sqs:ReceiveMessage"]}
+				]}
+			]`,
+		},
+		{
+			name: "actions and groups",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","actions":["sqs:ReceiveMessage"],
+				 "action_groups":[{"name":"READ","actions":["sqs:GetQueueAttributes"]}]}
+			]`,
+			wantErr: "must supply exactly one of actions or action_groups",
+		},
+		{
+			name:    "no actions or groups",
+			config:  `[{"resource_type":"AWS::SQS::Queue"}]`,
+			wantErr: "must supply exactly one of actions or action_groups",
+		},
+		{
+			name: "duplicate group",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ","actions":["sqs:ReceiveMessage"]},
+					{"name":"READ","actions":["sqs:GetQueueAttributes"]}
+				]}
+			]`,
+			wantErr: "duplicate action group",
+		},
+		{
+			name: "duplicate action case insensitive",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ","actions":["sqs:ReceiveMessage"]},
+					{"name":"WRITE","actions":["SQS:receivemessage"]}
+				]}
+			]`,
+			wantErr: "belongs to both",
+		},
+		{
+			name: "missing group name",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"actions":["sqs:ReceiveMessage"]}
+				]}
+			]`,
+			wantErr: "is missing name",
+		},
+		{
+			name: "missing group actions",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ"}
+				]}
+			]`,
+			wantErr: "is missing actions",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(path, []byte(tc.config), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := loadConfig(path)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("wanted error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateOutputOptions(t *testing.T) {
+	legacy := []ConfigEntry{{ResourceType: "AWS::SQS::Queue", Actions: []string{"sqs:ReceiveMessage"}}}
+	grouped := []ConfigEntry{{
+		ResourceType: "AWS::SQS::Queue",
+		ActionGroups: []ActionGroup{{Name: "READ", Actions: []string{"sqs:ReceiveMessage"}}},
+	}}
+
+	tests := []struct {
+		name    string
+		opts    cli.Flags
+		config  []ConfigEntry
+		wantErr bool
+	}{
+		{"legacy csv", cli.Flags{Format: formatCSV}, legacy, false},
+		{"groups in legacy csv", cli.Flags{Format: formatCSV}, grouped, false},
+		{"grouped csv", cli.Flags{Format: formatGroupedCSV, ResourceBatchSize: 1}, grouped, false},
+		{"grouped jsonl", cli.Flags{Format: formatGroupedJSONL, ResourceBatchSize: 1}, grouped, false},
+		{
+			"legacy config grouped output",
+			cli.Flags{Format: formatGroupedCSV, ResourceBatchSize: 1},
+			legacy,
+			true,
+		},
+		{"invalid batch size", cli.Flags{Format: formatGroupedCSV}, grouped, true},
+		{"invalid format", cli.Flags{Format: "xml", ResourceBatchSize: 1}, grouped, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOutputOptions(&tc.opts, tc.config)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateOutputOptions() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCollapseS3Arn(t *testing.T) {
+	if got := collapseS3Arn("arn:aws:s3:::example/key"); got != "arn:aws:s3:::example" {
+		t.Fatalf("unexpected collapsed ARN: %s", got)
+	}
+	want := "arn:aws:sqs:us-east-1:111111111111:example"
+	if got := collapseS3Arn(want); got != want {
+		t.Fatalf("unexpected non-S3 ARN: %s", got)
+	}
+}

--- a/cmd/yams/audit/audit_test.go
+++ b/cmd/yams/audit/audit_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -53,14 +54,39 @@ func TestLoadConfig(t *testing.T) {
 			wantErr: "duplicate action group",
 		},
 		{
-			name: "duplicate action case insensitive",
+			name: "duplicate action canonical alias",
 			config: `[
 				{"resource_type":"AWS::SQS::Queue","action_groups":[
 					{"name":"READ","actions":["sqs:ReceiveMessage"]},
-					{"name":"WRITE","actions":["SQS:receivemessage"]}
+					{"name":"WRITE","actions":["SQS.receivemessage"]}
 				]}
 			]`,
 			wantErr: "belongs to both",
+		},
+		{
+			name: "duplicate action in group",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ","actions":["sqs:ReceiveMessage","SQS.receivemessage"]}
+				]}
+			]`,
+			wantErr: "duplicate action",
+		},
+		{
+			name: "unknown legacy action",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","actions":["sqs:NotAnAction"]}
+			]`,
+			wantErr: "unknown action",
+		},
+		{
+			name: "unknown grouped action",
+			config: `[
+				{"resource_type":"AWS::SQS::Queue","action_groups":[
+					{"name":"READ","actions":["sqs:NotAnAction"]}
+				]}
+			]`,
+			wantErr: "unknown action",
 		},
 		{
 			name: "missing group name",
@@ -100,6 +126,37 @@ func TestLoadConfig(t *testing.T) {
 				t.Fatalf("wanted error containing %q, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestLoadConfigCanonicalizesActions(t *testing.T) {
+	config := `[
+		{"resource_type":"AWS::SQS::Queue","actions":["SQS.receivemessage"]},
+		{"resource_type":"AWS::SNS::Topic","action_groups":[
+			{"name":"WRITE","actions":["SNS-PUBLISH"]}
+		]}
+	]`
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ConfigEntry{
+		{
+			ResourceType: "AWS::SQS::Queue",
+			Actions:      []string{"sqs:ReceiveMessage"},
+		},
+		{
+			ResourceType: "AWS::SNS::Topic",
+			ActionGroups: []ActionGroup{{Name: "WRITE", Actions: []string{"sns:Publish"}}},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected config:\n got: %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/cmd/yams/audit/grouped.go
+++ b/cmd/yams/audit/grouped.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"sort"
 
-	"github.com/nsiow/yams/pkg/aws/sar"
 	"github.com/nsiow/yams/pkg/entities"
 	"github.com/nsiow/yams/pkg/sim"
 )
@@ -45,11 +44,7 @@ func processGroupedEntry(
 	actionGroups := make(map[string]int)
 	for groupIndex, group := range entry.ActionGroups {
 		for _, action := range group.Actions {
-			resolved, ok := sar.LookupString(action)
-			if !ok {
-				return 0, 0, fmt.Errorf("unknown action %q", action)
-			}
-			actionGroups[resolved.ShortName()] = groupIndex
+			actionGroups[action] = groupIndex
 		}
 	}
 

--- a/cmd/yams/audit/grouped.go
+++ b/cmd/yams/audit/grouped.go
@@ -1,0 +1,185 @@
+package audit
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/nsiow/yams/pkg/aws/sar"
+	"github.com/nsiow/yams/pkg/entities"
+	"github.com/nsiow/yams/pkg/sim"
+)
+
+type groupedWriter interface {
+	WriteGroup(resource, group string, principals []string) error
+	Flush() error
+}
+
+// processGroupedEntry simulates one resource type in bounded batches and emits complete groups.
+func processGroupedEntry(
+	simulator *sim.Simulator,
+	frozenPrincipals []*entities.FrozenPrincipal,
+	entry ConfigEntry,
+	opts sim.Options,
+	batchSize int,
+	w groupedWriter,
+) (int, int, error) {
+	var resourceArns []string
+	for resource := range simulator.Universe.Resources() {
+		if resource.Type == entry.ResourceType {
+			resourceArns = append(resourceArns, resource.Arn)
+		}
+	}
+	sort.Strings(resourceArns)
+
+	if len(resourceArns) == 0 {
+		slog.Info("no resources found for type", "type", entry.ResourceType)
+		return 0, 0, nil
+	}
+
+	principalIndexes := make(map[string]int, len(frozenPrincipals))
+	for i, principal := range frozenPrincipals {
+		principalIndexes[principal.Arn] = i
+	}
+
+	actionGroups := make(map[string]int)
+	for groupIndex, group := range entry.ActionGroups {
+		for _, action := range group.Actions {
+			resolved, ok := sar.LookupString(action)
+			if !ok {
+				return 0, 0, fmt.Errorf("unknown action %q", action)
+			}
+			actionGroups[resolved.ShortName()] = groupIndex
+		}
+	}
+
+	slog.Info("processing grouped entry",
+		"type", entry.ResourceType,
+		"resources", len(resourceArns),
+		"actions", len(entry.allActions()),
+		"groups", len(entry.ActionGroups),
+		"principals", len(frozenPrincipals),
+		"batch_size", batchSize)
+
+	var totalGroups, totalRelationships int
+	for start := 0; start < len(resourceArns); start += batchSize {
+		end := min(start+batchSize, len(resourceArns))
+		groups, relationships, err := processGroupedBatch(
+			simulator,
+			frozenPrincipals,
+			principalIndexes,
+			resourceArns[start:end],
+			entry,
+			actionGroups,
+			opts,
+			w,
+		)
+		if err != nil {
+			return 0, 0, err
+		}
+		totalGroups += groups
+		totalRelationships += relationships
+	}
+
+	slog.Info("grouped entry complete",
+		"type", entry.ResourceType,
+		"groups", totalGroups,
+		"relationships", totalRelationships)
+
+	return totalGroups, totalRelationships, nil
+}
+
+func processGroupedBatch(
+	simulator *sim.Simulator,
+	frozenPrincipals []*entities.FrozenPrincipal,
+	principalIndexes map[string]int,
+	resourceArns []string,
+	entry ConfigEntry,
+	actionGroups map[string]int,
+	opts sim.Options,
+	w groupedWriter,
+) (int, int, error) {
+	expanded, err := simulator.ExpandResources(resourceArns, opts)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to expand resources: %w", err)
+	}
+
+	frozenResources, err := simulator.FreezeResources(expanded, opts)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to freeze resources: %w", err)
+	}
+
+	resourceIndexes := make(map[string]int, len(resourceArns))
+	for i, resource := range resourceArns {
+		resourceIndexes[resource] = i
+	}
+
+	wordCount := (len(frozenPrincipals) + 63) / 64
+	membership := make([][][]uint64, len(resourceArns))
+	for resourceIndex := range membership {
+		membership[resourceIndex] = make([][]uint64, len(entry.ActionGroups))
+		for groupIndex := range membership[resourceIndex] {
+			membership[resourceIndex][groupIndex] = make([]uint64, wordCount)
+		}
+	}
+
+	var resultErr error
+	err = simulator.ProductFrozenStreaming(
+		frozenPrincipals,
+		entry.allActions(),
+		frozenResources,
+		opts,
+		func(tuple sim.AccessTuple) {
+			if resultErr != nil {
+				return
+			}
+
+			groupIndex, ok := actionGroups[tuple.Action]
+			if !ok {
+				resultErr = fmt.Errorf("action %q is not mapped to a group", tuple.Action)
+				return
+			}
+			resourceIndex, ok := resourceIndexes[collapseS3Arn(tuple.Resource)]
+			if !ok {
+				resultErr = fmt.Errorf("result resource %q is not in the current batch", tuple.Resource)
+				return
+			}
+			principalIndex, ok := principalIndexes[tuple.Principal]
+			if !ok {
+				resultErr = fmt.Errorf("result principal %q is not frozen", tuple.Principal)
+				return
+			}
+
+			membership[resourceIndex][groupIndex][principalIndex/64] |= 1 << (principalIndex % 64)
+		},
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("simulation error: %w", err)
+	}
+	if resultErr != nil {
+		return 0, 0, resultErr
+	}
+
+	var relationships int
+	for resourceIndex, resource := range resourceArns {
+		for groupIndex, group := range entry.ActionGroups {
+			principals := principalsFromBits(membership[resourceIndex][groupIndex], frozenPrincipals)
+			if err := w.WriteGroup(resource, group.Name, principals); err != nil {
+				return 0, 0, fmt.Errorf("unable to write group: %w", err)
+			}
+			relationships += len(principals)
+		}
+	}
+
+	return len(resourceArns) * len(entry.ActionGroups), relationships, nil
+}
+
+func principalsFromBits(bits []uint64, frozenPrincipals []*entities.FrozenPrincipal) []string {
+	principals := make([]string, 0)
+	for principalIndex, principal := range frozenPrincipals {
+		if bits[principalIndex/64]&(1<<(principalIndex%64)) != 0 {
+			principals = append(principals, principal.Arn)
+		}
+	}
+	return principals
+}

--- a/cmd/yams/audit/grouped_test.go
+++ b/cmd/yams/audit/grouped_test.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -94,6 +95,83 @@ func TestProcessGroupedEntry(t *testing.T) {
 			{Name: "WRITE", Actions: []string{"sqs:SendMessage"}},
 		},
 	}
+	want := []capturedGroup{
+		{resource: queueA, group: "READ", principals: []string{readPrincipalArn}},
+		{resource: queueA, group: "WRITE", principals: []string{writePrincipalArn}},
+		{resource: queueB, group: "READ", principals: []string{}},
+		{resource: queueB, group: "WRITE", principals: []string{}},
+	}
+	for _, batchSize := range []int{1, 256} {
+		t.Run(fmt.Sprintf("batch_size_%d", batchSize), func(t *testing.T) {
+			writer := &capturingGroupedWriter{}
+			groups, relationships, err := processGroupedEntry(
+				simulator,
+				frozenPrincipals,
+				entry,
+				opts,
+				batchSize,
+				writer,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if groups != 4 || relationships != 2 {
+				t.Fatalf(
+					"got groups=%d relationships=%d, want groups=4 relationships=2",
+					groups,
+					relationships,
+				)
+			}
+			if !reflect.DeepEqual(writer.groups, want) {
+				t.Fatalf("unexpected groups:\n got: %#v\nwant: %#v", writer.groups, want)
+			}
+		})
+	}
+}
+
+func TestProcessGroupedEntryCollapsesS3Resources(t *testing.T) {
+	const accountID = "111111111111"
+	principalArn := "arn:aws:iam::" + accountID + ":role/reader"
+	bucketArn := "arn:aws:s3:::example-bucket"
+
+	principal := entities.Principal{
+		Type:      "AWS::IAM::Role",
+		AccountId: accountID,
+		Arn:       principalArn,
+		InlinePolicies: []policy.Policy{{
+			Statement: []policy.Statement{{
+				Effect:   policy.EFFECT_ALLOW,
+				Action:   []string{"s3:GetObject", "s3:ListBucket"},
+				Resource: []string{bucketArn, bucketArn + "/*"},
+			}},
+		}},
+	}
+
+	simulator, err := sim.NewSimulator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	simulator.Universe = entities.NewBuilder().
+		WithPrincipals(principal).
+		WithResources(entities.Resource{
+			Type:      "AWS::S3::Bucket",
+			AccountId: accountID,
+			Arn:       bucketArn,
+		}).
+		Build()
+
+	opts := sim.NewOptions()
+	frozenPrincipals, err := simulator.FreezePrincipals([]string{principalArn}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := ConfigEntry{
+		ResourceType: "AWS::S3::Bucket",
+		ActionGroups: []ActionGroup{{
+			Name:    "READ",
+			Actions: []string{"s3:GetObject", "s3:ListBucket"},
+		}},
+	}
 	writer := &capturingGroupedWriter{}
 
 	groups, relationships, err := processGroupedEntry(
@@ -107,18 +185,35 @@ func TestProcessGroupedEntry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if groups != 4 || relationships != 2 {
-		t.Fatalf("got groups=%d relationships=%d, want groups=4 relationships=2", groups, relationships)
+	if groups != 1 || relationships != 1 {
+		t.Fatalf("got groups=%d relationships=%d, want groups=1 relationships=1", groups, relationships)
 	}
-
-	want := []capturedGroup{
-		{resource: queueA, group: "READ", principals: []string{readPrincipalArn}},
-		{resource: queueA, group: "WRITE", principals: []string{writePrincipalArn}},
-		{resource: queueB, group: "READ", principals: []string{}},
-		{resource: queueB, group: "WRITE", principals: []string{}},
-	}
+	want := []capturedGroup{{
+		resource:   bucketArn,
+		group:      "READ",
+		principals: []string{principalArn},
+	}}
 	if !reflect.DeepEqual(writer.groups, want) {
 		t.Fatalf("unexpected groups:\n got: %#v\nwant: %#v", writer.groups, want)
+	}
+}
+
+func TestPrincipalsFromBitsAcrossWords(t *testing.T) {
+	frozenPrincipals := make([]*entities.FrozenPrincipal, 66)
+	for i := range frozenPrincipals {
+		frozenPrincipals[i] = &entities.FrozenPrincipal{
+			Arn: fmt.Sprintf("arn:aws:iam::111111111111:role/principal-%02d", i),
+		}
+	}
+
+	got := principalsFromBits([]uint64{1 << 63, 0b11}, frozenPrincipals)
+	want := []string{
+		frozenPrincipals[63].Arn,
+		frozenPrincipals[64].Arn,
+		frozenPrincipals[65].Arn,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected principals:\n got: %#v\nwant: %#v", got, want)
 	}
 }
 

--- a/cmd/yams/audit/grouped_test.go
+++ b/cmd/yams/audit/grouped_test.go
@@ -1,0 +1,165 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/nsiow/yams/pkg/entities"
+	"github.com/nsiow/yams/pkg/policy"
+	"github.com/nsiow/yams/pkg/sim"
+)
+
+type capturedGroup struct {
+	resource   string
+	group      string
+	principals []string
+}
+
+type capturingGroupedWriter struct {
+	groups []capturedGroup
+}
+
+func (w *capturingGroupedWriter) WriteGroup(resource, group string, principals []string) error {
+	w.groups = append(w.groups, capturedGroup{
+		resource:   resource,
+		group:      group,
+		principals: principals,
+	})
+	return nil
+}
+
+func (w *capturingGroupedWriter) Flush() error {
+	return nil
+}
+
+func TestProcessGroupedEntry(t *testing.T) {
+	const accountID = "111111111111"
+	readPrincipalArn := "arn:aws:iam::" + accountID + ":role/a-read"
+	writePrincipalArn := "arn:aws:iam::" + accountID + ":role/b-write"
+	queueA := "arn:aws:sqs:us-east-1:" + accountID + ":a-queue"
+	queueB := "arn:aws:sqs:us-east-1:" + accountID + ":b-queue"
+
+	readPrincipal := entities.Principal{
+		Type:      "AWS::IAM::Role",
+		AccountId: accountID,
+		Arn:       readPrincipalArn,
+		InlinePolicies: []policy.Policy{{
+			Statement: []policy.Statement{{
+				Effect:   policy.EFFECT_ALLOW,
+				Action:   []string{"sqs:ReceiveMessage", "sqs:GetQueueAttributes"},
+				Resource: []string{queueA},
+			}},
+		}},
+	}
+	writePrincipal := entities.Principal{
+		Type:      "AWS::IAM::Role",
+		AccountId: accountID,
+		Arn:       writePrincipalArn,
+		InlinePolicies: []policy.Policy{{
+			Statement: []policy.Statement{{
+				Effect:   policy.EFFECT_ALLOW,
+				Action:   []string{"sqs:SendMessage"},
+				Resource: []string{queueA},
+			}},
+		}},
+	}
+
+	simulator, err := sim.NewSimulator()
+	if err != nil {
+		t.Fatal(err)
+	}
+	simulator.Universe = entities.NewBuilder().
+		WithPrincipals(writePrincipal, readPrincipal).
+		WithResources(
+			entities.Resource{Type: "AWS::SQS::Queue", AccountId: accountID, Arn: queueB},
+			entities.Resource{Type: "AWS::SQS::Queue", AccountId: accountID, Arn: queueA},
+		).
+		Build()
+
+	opts := sim.NewOptions()
+	frozenPrincipals, err := simulator.FreezePrincipals(
+		[]string{readPrincipalArn, writePrincipalArn},
+		opts,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := ConfigEntry{
+		ResourceType: "AWS::SQS::Queue",
+		ActionGroups: []ActionGroup{
+			{Name: "READ", Actions: []string{"sqs:ReceiveMessage", "sqs:GetQueueAttributes"}},
+			{Name: "WRITE", Actions: []string{"sqs:SendMessage"}},
+		},
+	}
+	writer := &capturingGroupedWriter{}
+
+	groups, relationships, err := processGroupedEntry(
+		simulator,
+		frozenPrincipals,
+		entry,
+		opts,
+		1,
+		writer,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if groups != 4 || relationships != 2 {
+		t.Fatalf("got groups=%d relationships=%d, want groups=4 relationships=2", groups, relationships)
+	}
+
+	want := []capturedGroup{
+		{resource: queueA, group: "READ", principals: []string{readPrincipalArn}},
+		{resource: queueA, group: "WRITE", principals: []string{writePrincipalArn}},
+		{resource: queueB, group: "READ", principals: []string{}},
+		{resource: queueB, group: "WRITE", principals: []string{}},
+	}
+	if !reflect.DeepEqual(writer.groups, want) {
+		t.Fatalf("unexpected groups:\n got: %#v\nwant: %#v", writer.groups, want)
+	}
+}
+
+func TestGroupedCSVWriter(t *testing.T) {
+	var output bytes.Buffer
+	w, err := newGroupedCSVWriter(&output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteGroup("resource-a", "READ", []string{"principal-a", "principal-b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteGroup("resource-b", "WRITE", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "resource,group,principal\n" +
+		"resource-a,READ,principal-a\n" +
+		"resource-a,READ,principal-b\n" +
+		"resource-b,WRITE,\n"
+	if output.String() != want {
+		t.Fatalf("unexpected CSV:\n%s", output.String())
+	}
+}
+
+func TestGroupedJSONLWriter(t *testing.T) {
+	var output bytes.Buffer
+	w := &groupedJSONLWriter{w: json.NewEncoder(&output)}
+	if err := w.WriteGroup("resource-a", "READ", []string{"principal-a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.WriteGroup("resource-b", "WRITE", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "{\"resource\":\"resource-a\",\"group\":\"READ\",\"principals\":[\"principal-a\"]}\n" +
+		"{\"resource\":\"resource-b\",\"group\":\"WRITE\",\"principals\":[]}\n"
+	if output.String() != want {
+		t.Fatalf("unexpected JSONL:\n%s", output.String())
+	}
+}

--- a/cmd/yams/audit/grouped_writer.go
+++ b/cmd/yams/audit/grouped_writer.go
@@ -1,0 +1,73 @@
+package audit
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type groupedCSVWriter struct {
+	w *csv.Writer
+}
+
+func newGroupedCSVWriter(w io.Writer) (*groupedCSVWriter, error) {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"resource", "group", "principal"}); err != nil {
+		return nil, err
+	}
+	return &groupedCSVWriter{w: cw}, nil
+}
+
+func (w *groupedCSVWriter) WriteGroup(resource, group string, principals []string) error {
+	if len(principals) == 0 {
+		return w.w.Write([]string{resource, group, ""})
+	}
+	for _, principal := range principals {
+		if err := w.w.Write([]string{resource, group, principal}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *groupedCSVWriter) Flush() error {
+	w.w.Flush()
+	return w.w.Error()
+}
+
+type groupedJSONLRecord struct {
+	Resource   string   `json:"resource"`
+	Group      string   `json:"group"`
+	Principals []string `json:"principals"`
+}
+
+type groupedJSONLWriter struct {
+	w *json.Encoder
+}
+
+func (w *groupedJSONLWriter) WriteGroup(resource, group string, principals []string) error {
+	if principals == nil {
+		principals = []string{}
+	}
+	return w.w.Encode(groupedJSONLRecord{
+		Resource:   resource,
+		Group:      group,
+		Principals: principals,
+	})
+}
+
+func (w *groupedJSONLWriter) Flush() error {
+	return nil
+}
+
+func newGroupedWriter(format string, w io.Writer) (groupedWriter, error) {
+	switch format {
+	case formatGroupedCSV:
+		return newGroupedCSVWriter(w)
+	case formatGroupedJSONL:
+		return &groupedJSONLWriter{w: json.NewEncoder(w)}, nil
+	default:
+		return nil, fmt.Errorf("unsupported grouped format %q", format)
+	}
+}

--- a/cmd/yams/cli/completion.go
+++ b/cmd/yams/cli/completion.go
@@ -35,7 +35,9 @@ _yams() {
             COMPREPLY=($(compgen -W "-s --server -p --principal -a --action -r --resource -c --context -o --overlay -x --exact --disable-shared-context -e --explain -t --trace" -- "${cur}"))
             ;;
         audit)
-            COMPREPLY=($(compgen -W "-s --source -f --config -o --out -c --context --overlay" -- "${cur}"))
+            local audit_flags="-s --source -f --config -o --out --format --resource-batch-size"
+            audit_flags+=" -c --context --overlay"
+            COMPREPLY=($(compgen -W "${audit_flags}" -- "${cur}"))
             ;;
         principals|resources|actions|accounts|policies)
             COMPREPLY=($(compgen -W "-s --server -q --query -k --key -f --freeze --format" -- "${cur}"))
@@ -58,7 +60,7 @@ _yams() {
         'server:Start the yams API server'
         'dump:Export AWS organization or config data'
         'sim:Simulate IAM permission checks'
-        'audit:Generate access summary CSV'
+        'audit:Generate an access audit'
         'principals:List or search IAM principals'
         'resources:List or search AWS resources'
         'actions:List or search IAM actions'
@@ -116,6 +118,8 @@ _yams() {
                         '*'{-s,--source}'[Data source]:source:_files' \
                         '(-f --config)'{-f,--config}'[Audit config file]:config:_files' \
                         '(-o --out)'{-o,--out}'[Output destination]:destination:_files' \
+                        '--format[Output format]:format:(csv grouped-csv grouped-jsonl)' \
+                        '--resource-batch-size[Resources per grouped batch]:count:' \
                         '*'{-c,--context}'[Context key=value]:context:' \
                         '*--overlay[Overlay file]:file:_files'
                     ;;

--- a/cmd/yams/cli/flags.go
+++ b/cmd/yams/cli/flags.go
@@ -64,7 +64,8 @@ type Flags struct {
 	Format string
 
 	// audit
-	Config string
+	Config            string
+	ResourceBatchSize int
 
 	// sim
 	Principal            string
@@ -270,7 +271,11 @@ func Parse() (*Flags, error) {
 		fs.StringVar(&opts.Config, "config", "", "path to audit config JSON file")
 
 		fs.StringVar(&opts.Out, "o", "", "alias for -out")
-		fs.StringVar(&opts.Out, "out", "", "destination for CSV output")
+		fs.StringVar(&opts.Out, "out", "", "destination for audit output")
+		fs.StringVar(&opts.Format, "format", "csv",
+			"output format: csv, grouped-csv, or grouped-jsonl")
+		fs.IntVar(&opts.ResourceBatchSize, "resource-batch-size", 256,
+			"number of resources to aggregate per batch for grouped output")
 
 		fs.Var(&opts.Context, "c", "alias for -context")
 		fs.Var(&opts.Context, "context", "additional request-context key=value pairs")

--- a/cmd/yams/cli/help.go
+++ b/cmd/yams/cli/help.go
@@ -25,7 +25,7 @@ var Commands = []CommandInfo{
 	{Name: "server", Description: "Start the yams API server"},
 	{Name: "dump", Description: "Export AWS organization or config data"},
 	{Name: "sim", Description: "Simulate IAM permission checks"},
-	{Name: "audit", Description: "Generate access summary CSV"},
+	{Name: "audit", Description: "Generate an access audit"},
 	{Name: "principals", Description: "List or search IAM principals (roles, users)", Aliases: []string{"p"}},
 	{Name: "resources", Description: "List or search AWS resources", Aliases: []string{"r"}},
 	{Name: "actions", Description: "List or search IAM actions", Aliases: []string{"a"}},

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,62 @@
+# Audit
+
+The `audit` command evaluates configured actions across every matching resource and principal in
+the supplied data sources. Audit runs locally against those sources and does not call the yams
+server.
+
+```shell
+yams audit \
+  --source config.json.gz \
+  --source org.json.gz \
+  --config misc/audit-config.json \
+  --out audit.csv
+```
+
+The default `csv` format preserves action-level results:
+
+```text
+resource,action,principal
+```
+
+## Logical Action Groups
+
+Actions can instead be mapped into logical groups. An action may belong to only one group within
+a resource entry.
+
+```json
+[
+  {
+    "resource_type": "AWS::SQS::Queue",
+    "action_groups": [
+      {
+        "name": "READ",
+        "actions": ["sqs:ReceiveMessage"]
+      },
+      {
+        "name": "WRITE",
+        "actions": ["sqs:SendMessage", "sqs:DeleteMessage"]
+      }
+    ]
+  }
+]
+```
+
+Use `--format grouped-csv` for one row per resource, group, and allowed principal:
+
+```text
+resource,group,principal
+arn:aws:sqs:us-east-1:111111111111:example,READ,arn:aws:iam::111111111111:role/reader
+```
+
+Use `--format grouped-jsonl` for one record per resource and group:
+
+```json
+{"resource":"arn:aws:sqs:us-east-1:111111111111:example","group":"READ","principals":[]}
+```
+
+Principals allowed by multiple actions in a group appear once. Resources with no allowed
+principals are retained: grouped JSONL uses an empty array and grouped CSV uses an empty principal
+field.
+
+Grouped output is deterministic and uses bounded resource batches. Adjust the default batch size
+of 256 with `--resource-batch-size` to trade aggregation memory for simulation overhead.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -54,9 +54,9 @@ Use `--format grouped-jsonl` for one record per resource and group:
 {"resource":"arn:aws:sqs:us-east-1:111111111111:example","group":"READ","principals":[]}
 ```
 
-Principals allowed by multiple actions in a group appear once. Resources with no allowed
-principals are retained: grouped JSONL uses an empty array and grouped CSV uses an empty principal
-field.
+A principal belongs to a group when at least one action in that group is allowed. Principals
+allowed by multiple actions in a group appear once. Resources with no allowed principals are
+retained: grouped JSONL uses an empty array and grouped CSV uses an empty principal field.
 
 Grouped output is deterministic and uses bounded resource batches. Adjust the default batch size
 of 256 with `--resource-batch-size` to trade aggregation memory for simulation overhead.

--- a/misc/audit-groups-config.json
+++ b/misc/audit-groups-config.json
@@ -1,0 +1,54 @@
+[
+  {
+    "resource_type": "AWS::S3::Bucket",
+    "action_groups": [
+      {
+        "name": "READ",
+        "actions": ["s3:GetObject"]
+      },
+      {
+        "name": "WRITE",
+        "actions": ["s3:PutObject", "s3:DeleteObject"]
+      }
+    ]
+  },
+  {
+    "resource_type": "AWS::SQS::Queue",
+    "action_groups": [
+      {
+        "name": "READ",
+        "actions": ["sqs:ReceiveMessage"]
+      },
+      {
+        "name": "WRITE",
+        "actions": ["sqs:SendMessage", "sqs:DeleteMessage"]
+      }
+    ]
+  },
+  {
+    "resource_type": "AWS::SNS::Topic",
+    "action_groups": [
+      {
+        "name": "READ",
+        "actions": ["sns:Subscribe"]
+      },
+      {
+        "name": "WRITE",
+        "actions": ["sns:Publish"]
+      }
+    ]
+  },
+  {
+    "resource_type": "AWS::DynamoDB::Table",
+    "action_groups": [
+      {
+        "name": "READ",
+        "actions": ["dynamodb:GetItem", "dynamodb:Query"]
+      },
+      {
+        "name": "WRITE",
+        "actions": ["dynamodb:PutItem", "dynamodb:DeleteItem"]
+      }
+    ]
+  }
+]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,5 +23,6 @@ nav:
   - Generating Data: generating_data.md
   - Inventory: inventory.md
   - Simulation: simulation.md
+  - Audit: audit.md
   - Deployment: deployment.md
   - API Reference: api.md


### PR DESCRIPTION
### Overview

This PR allows customization of the `audit` functionality within `yams`, so that end users can create groupings of actions with meaning for their organization.

For example, `READ` to some may mean data-plane reads only, while in other cases `READ` may include resource-level describe operations as well.